### PR TITLE
Add participant registration and live proctor roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,21 @@
 
 ## 🛡️ Zero Trust Agentic Design Sprint
 
-An interactive playbook for running the **Zero Trust Agentic Design Sprint** design-clinic group activity — a timed, four-person tabletop exercise. It adds a live 60-minute facilitator timer, auto-tracked phases, timed injection reveals, tickable checklists, and a fillable solution sheet on top of the printable playbook.
+An interactive playbook for running the **Zero Trust Agentic Design Sprint** design-clinic group activity — a timed, four-person tabletop exercise. It adds a live 60-minute facilitator timer, auto-tracked phases, timed injection reveals, tickable checklists, a fillable solution sheet, a per-person **"take your seat" persona** view, and a live **team roster** for the proctor.
 
-➡️ **[Open `zero-trust-design-sprint.html`](./zero-trust-design-sprint.html)** (when served via GitHub Pages it lives at `/zero-trust-design-sprint.html`).
+**Pages**
+
+- ➡️ **[Participant page — `zero-trust-design-sprint.html`](./zero-trust-design-sprint.html)** — the playbook each participant opens (served at `/zero-trust-design-sprint.html`).
+- 👁️ **[Proctor roster — `proctor.html`](./proctor.html)** — live view of all teams and members as they join.
+
+**Live cross-device roster (optional setup)**
+
+Participants enter their **name, email, and team name** when they take a seat, and the proctor sees everyone grouped by team on `proctor.html`. Because GitHub Pages is static, sharing that data across devices needs a small backend:
+
+- Fill in **[`firebase-config.js`](./firebase-config.js)** with your Firebase project values (step-by-step setup is in that file). Firestore then syncs the roster live across every device.
+- Until it's configured, everything still works in **single-device mode** (localStorage) so you can demo it on one machine.
+- Optional `?room=CODE` on both pages scopes a roster to one session (handy when running several clinics).
+- Note: the roster stores participant **emails (PII)** — use the provided Firestore rules and clear the data after your session.
 
 ---
 

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,48 @@
+/* ============================================================================
+   Firebase configuration for the Zero Trust Agentic Design Sprint
+   ----------------------------------------------------------------------------
+   This powers the shared, cross-device roster: participants register (name,
+   email, team) on their own devices, and the proctor sees everyone live on
+   proctor.html.
+
+   The page works WITHOUT this configured — it falls back to a single-device
+   (localStorage) roster so nothing breaks. To enable the real cross-device
+   proctor view, do the following one-time setup:
+
+   1. Go to https://console.firebase.google.com/ and create a project (free).
+   2. In the project, add a Web app (</>) — copy the "firebaseConfig" values.
+   3. Build → Firestore Database → Create database (Production mode is fine).
+   4. Firestore → Rules: for a short, facilitated clinic you can use the rules
+      below. They allow reading/writing player records but block deleting them
+      from the client. Tighten or delete the data after your session — the
+      records contain participant emails (PII).
+
+        rules_version = '2';
+        service cloud.firestore {
+          match /databases/{database}/documents {
+            match /players/{id} {
+              allow read: if true;
+              allow create, update: if
+                request.resource.data.name is string &&
+                request.resource.data.name.size() < 120 &&
+                request.resource.data.email.size() < 200 &&
+                request.resource.data.teamName.size() < 120;
+              allow delete: if false;
+            }
+          }
+        }
+
+   5. Paste your values below (replace every PASTE_… placeholder) and commit.
+
+   NOTE: Firebase web config values are NOT secrets — they're meant to ship in
+   the browser. Your data is protected by the Firestore rules above, not by
+   hiding these values.
+   ========================================================================== */
+window.FIREBASE_CONFIG = {
+  apiKey: "PASTE_API_KEY",
+  authDomain: "PASTE_PROJECT.firebaseapp.com",
+  projectId: "PASTE_PROJECT_ID",
+  storageBucket: "PASTE_PROJECT.appspot.com",
+  messagingSenderId: "PASTE_SENDER_ID",
+  appId: "PASTE_APP_ID"
+};

--- a/proctor.html
+++ b/proctor.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Proctor · Live Roster — Zero Trust Agentic Design Sprint</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --paper:#E9EEF5;--surface:#FFFFFF;--ink:#0E1A2B;--ink-soft:#46566E;--ink-faint:#7E8CA1;
+    --line:#CBD5E3;--line-soft:#E1E8F1;--navy:#122A47;--navy-deep:#0A1830;
+    --cyan:#0FA9BE;--cyan-deep:#0A7C8C;--amber:#E2891F;--red:#DB4A4A;--green:#27A276;
+    --shadow:0 1px 0 rgba(14,26,43,.04), 0 18px 40px -28px rgba(14,26,43,.55);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;font-family:"IBM Plex Sans",system-ui,sans-serif;color:var(--ink);background:#F3F6FA;line-height:1.55;-webkit-font-smoothing:antialiased}
+  h1,h2,h3,h4{font-family:"Chakra Petch",sans-serif;margin:0;line-height:1.1}
+  .mono{font-family:"IBM Plex Mono",monospace}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 22px}
+
+  .top{background:radial-gradient(120% 160% at 88% -20%,#1c3a5e 0%,var(--navy) 45%,var(--navy-deep) 100%);color:#EAF1F8;border-bottom:3px solid var(--cyan)}
+  .top-in{padding:26px 0 24px;display:flex;flex-wrap:wrap;align-items:flex-end;gap:18px}
+  .eyebrow{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:500;letter-spacing:.22em;text-transform:uppercase;color:#7FE2EF}
+  .top h1{font-size:clamp(24px,4vw,38px);font-weight:700;color:#fff;margin:.28em 0 .1em}
+  .top .sub{color:#AEC4DC;font-size:14px}
+  .top .spacer{flex:1}
+  .stats{display:flex;gap:10px}
+  .stat{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.14);border-radius:11px;padding:8px 14px;min-width:78px;text-align:center}
+  .stat b{font-family:"Chakra Petch";font-size:24px;display:block;color:#fff;line-height:1}
+  .stat small{font-family:"IBM Plex Mono";font-size:9.5px;letter-spacing:.14em;text-transform:uppercase;color:#8FA8C4}
+
+  .bar{display:flex;flex-wrap:wrap;align-items:center;gap:12px;margin:18px 0 4px;padding:13px 16px;background:var(--surface);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow)}
+  .bar .status{display:inline-flex;align-items:center;gap:8px;font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--ink-soft)}
+  .bar .status .dot{width:9px;height:9px;border-radius:50%;background:var(--ink-faint)}
+  .bar .status.live .dot{background:var(--green);box-shadow:0 0 0 3px rgba(39,162,118,.18);animation:pulse 1.4s infinite}
+  .bar .status.local .dot{background:var(--amber)}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.3}}
+  .bar .room{display:inline-flex;align-items:center;gap:6px;font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--ink-soft)}
+  .bar .room input{border:1px solid var(--line);border-radius:8px;padding:6px 9px;font-family:"IBM Plex Mono",monospace;font-size:12px;width:130px;outline:none}
+  .bar .room input:focus{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.12)}
+  .bar .spacer{flex:1}
+  .btn{font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;letter-spacing:.04em;color:var(--ink);background:#F4F7FB;border:1px solid var(--line);border-radius:8px;padding:7px 12px;cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:background .15s,border-color .15s}
+  .btn:hover{background:#E8EEF6;border-color:var(--cyan)}
+  .btn.primary{background:var(--navy);border-color:var(--navy);color:#fff}
+  .btn.primary:hover{background:#1b3a5f}
+  .btn svg{width:14px;height:14px;stroke-width:2}
+
+  .notice{margin:12px 0 0;padding:11px 14px;border-radius:11px;font-size:13px;border:1px solid #F0CE97;background:#FBEBD3;color:#8a560f}
+  .notice b{color:#6e440a}
+
+  .teams{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:16px;margin:18px 0 40px}
+  .team{background:var(--surface);border:1px solid var(--line);border-radius:14px;box-shadow:var(--shadow);overflow:hidden;border-top:4px solid var(--cyan)}
+  .team-h{padding:14px 16px;border-bottom:1px solid var(--line-soft);display:flex;align-items:center;justify-content:space-between;gap:10px}
+  .team-h h3{font-size:17px}
+  .team-h .cnt{font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;color:#fff;background:var(--navy);border-radius:20px;padding:3px 10px}
+  .member{display:flex;align-items:center;gap:11px;padding:11px 16px;border-bottom:1px dashed var(--line-soft)}
+  .member:last-child{border-bottom:none}
+  .member .rc{font-family:"IBM Plex Mono",monospace;font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#fff;border-radius:5px;padding:3px 7px;white-space:nowrap;min-width:74px;text-align:center}
+  .member .who{min-width:0;flex:1;display:flex;flex-direction:column;line-height:1.3}
+  .member .who .nm{font-size:14px;font-weight:600;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .member .who .em{font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--ink-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .member .jt{font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:var(--ink-faint);white-space:nowrap}
+
+  .empty{margin:40px auto;max-width:520px;text-align:center;color:var(--ink-soft)}
+  .empty svg{width:46px;height:46px;color:var(--ink-faint);margin-bottom:12px}
+  .empty h3{font-size:18px;margin-bottom:6px;color:var(--ink)}
+  .empty code{font-family:"IBM Plex Mono",monospace;background:#EEF3F9;border:1px solid var(--line-soft);border-radius:6px;padding:2px 7px;font-size:12.5px}
+  .foot{margin:30px 0;color:var(--ink-faint);font-family:"IBM Plex Mono",monospace;font-size:11px;text-align:center}
+  .foot a{color:var(--cyan-deep)}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap top-in">
+    <div>
+      <span class="eyebrow">Zero Trust Agentic Design Sprint · Facilitator</span>
+      <h1>Live Team Roster</h1>
+      <div class="sub">Everyone who has taken a seat, grouped by team — updates in real time.</div>
+    </div>
+    <div class="spacer"></div>
+    <div class="stats">
+      <div class="stat"><b id="statTeams">0</b><small>Teams</small></div>
+      <div class="stat"><b id="statPlayers">0</b><small>Players</small></div>
+    </div>
+  </div>
+</header>
+
+<div class="wrap">
+  <div class="bar">
+    <span class="status" id="status"><span class="dot"></span><span id="statusText">Connecting…</span></span>
+    <span class="room">room:&nbsp;<input id="roomInput" type="text" spellcheck="false"><button class="btn" id="roomGo">Switch</button></span>
+    <span class="spacer"></span>
+    <button class="btn" id="btnRefresh" title="Reload"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4v6h6"/><path d="M4 10a8 8 0 113 8"/></svg>Reload</button>
+    <button class="btn primary" id="btnCsv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M5 21h14"/></svg>Export CSV</button>
+  </div>
+  <div class="notice" id="localNotice" hidden>
+    <b>Single-device mode.</b> Firebase isn't configured, so this roster only shows people who joined <b>on this device/browser</b>. To see every participant's device live, fill in <code>firebase-config.js</code> (setup steps are in that file).
+  </div>
+
+  <div class="teams" id="teams"></div>
+  <div class="empty" id="empty" hidden>
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 00-3-3.87"/></svg>
+    <h3>No one has joined yet</h3>
+    <p>Share the participant page and ask each person to <b>Take your seat</b> (name, email, team). They'll appear here automatically.</p>
+  </div>
+
+  <div class="foot">Roster room: <b id="footRoom">default</b> · <a href="zero-trust-design-sprint.html">← Back to the participant page</a></div>
+</div>
+
+<script src="firebase-config.js"></script>
+<script src="roster.js"></script>
+<script>
+(function(){
+  "use strict";
+  var $ = function(s){ return document.querySelector(s); };
+  var ROLE_COLORS = { conductor:"#E2891F", critic:"#DB4A4A", architect:"#0FA9BE", scribe:"#27A276", facilitator:"#7E8CA1" };
+  var ROLE_ORDER = { conductor:0, critic:1, architect:2, scribe:3, facilitator:4 };
+  var ROOM = (new URLSearchParams(location.search)).get("room") || "default";
+  $("#roomInput").value = ROOM;
+  $("#footRoom").textContent = ROOM;
+  var latest = [];
+
+  function esc(s){ return String(s==null?"":s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
+  function fmtTime(ms){ if(!ms) return ""; var d=new Date(ms); var h=d.getHours(), m=d.getMinutes(); return (h<10?"0":"")+h+":"+(m<10?"0":"")+m; }
+
+  function render(players){
+    latest = players || [];
+    // group by team name (case-insensitive), preserve first-seen display name
+    var groups = {}, order = [];
+    latest.forEach(function(p){
+      var tn = (p.teamName||"(no team)").trim() || "(no team)";
+      var key = tn.toLowerCase();
+      if(!groups[key]){ groups[key] = { name: tn, members: [] }; order.push(key); }
+      groups[key].members.push(p);
+    });
+    order.sort(function(a,b){ return groups[a].name.localeCompare(groups[b].name); });
+
+    $("#statTeams").textContent = order.length;
+    $("#statPlayers").textContent = latest.length;
+
+    var teamsEl = $("#teams");
+    if(!latest.length){ teamsEl.innerHTML=""; $("#empty").hidden=false; return; }
+    $("#empty").hidden=true;
+
+    teamsEl.innerHTML = order.map(function(key){
+      var g = groups[key];
+      g.members.sort(function(a,b){
+        var oa = ROLE_ORDER[a.roleKey]!=null?ROLE_ORDER[a.roleKey]:9, ob = ROLE_ORDER[b.roleKey]!=null?ROLE_ORDER[b.roleKey]:9;
+        return oa-ob || (a.joinedAt||0)-(b.joinedAt||0);
+      });
+      var rows = g.members.map(function(p){
+        var col = ROLE_COLORS[p.roleKey] || "#7E8CA1";
+        return '<div class="member">'+
+          '<span class="rc" style="background:'+col+'">'+esc(p.role||"—")+'</span>'+
+          '<span class="who"><span class="nm">'+esc(p.name||"—")+'</span><span class="em">'+esc(p.email||"")+'</span></span>'+
+          '<span class="jt">'+fmtTime(p.joinedAt)+'</span>'+
+        '</div>';
+      }).join("");
+      return '<div class="team"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+rows+'</div>';
+    }).join("");
+  }
+
+  function toCsv(){
+    var rows = [["Team","Name","Email","Role","Joined"]];
+    latest.slice().sort(function(a,b){ return (a.teamName||"").localeCompare(b.teamName||""); }).forEach(function(p){
+      rows.push([p.teamName||"", p.name||"", p.email||"", p.role||"", p.joinedAt?new Date(p.joinedAt).toISOString():""]);
+    });
+    return rows.map(function(r){ return r.map(function(c){ return '"'+String(c).replace(/"/g,'""')+'"'; }).join(","); }).join("\r\n");
+  }
+  $("#btnCsv").addEventListener("click", function(){
+    var blob = new Blob([toCsv()], {type:"text/csv"});
+    var a = document.createElement("a"); a.href = URL.createObjectURL(blob);
+    a.download = "roster-"+ROOM+".csv"; document.body.appendChild(a); a.click();
+    setTimeout(function(){ URL.revokeObjectURL(a.href); document.body.removeChild(a); }, 100);
+  });
+  $("#btnRefresh").addEventListener("click", function(){ location.reload(); });
+  $("#roomGo").addEventListener("click", function(){
+    var v = ($("#roomInput").value||"").trim() || "default";
+    location.search = "?room="+encodeURIComponent(v);
+  });
+  $("#roomInput").addEventListener("keydown", function(e){ if(e.key==="Enter") $("#roomGo").click(); });
+
+  render([]);
+  if(window.ZTDSRoster){
+    window.ZTDSRoster.init(ROOM).then(function(adapter){
+      var live = adapter.mode==="firebase";
+      $("#status").className = "status "+(live?"live":"local");
+      $("#statusText").textContent = live ? "Live · Firebase" : "Single-device (local)";
+      $("#localNotice").hidden = live;
+      adapter.subscribe(render);
+    });
+  } else {
+    $("#statusText").textContent = "Roster unavailable";
+  }
+})();
+</script>
+</body>
+</html>

--- a/roster.js
+++ b/roster.js
@@ -1,0 +1,62 @@
+/* ============================================================================
+   Shared roster for the Zero Trust Agentic Design Sprint.
+   Used by both the participant page and proctor.html.
+
+   Exposes window.ZTDSRoster.init(room) -> Promise<adapter>, where adapter is:
+     { mode, join(player), subscribe(cb) -> unsubscribe }
+
+   If firebase-config.js is filled in, it uses Firestore (real cross-device
+   sync). Otherwise it transparently falls back to a single-device localStorage
+   roster so the pages still work (useful for testing / one-device demos).
+   ========================================================================== */
+(function () {
+  "use strict";
+  var SDK = "https://www.gstatic.com/firebasejs/10.12.2/";
+
+  function lsKey(room) { return "ztds.roster." + room; }
+
+  function localAdapter(room) {
+    function readAll() { try { return JSON.parse(localStorage.getItem(lsKey(room)) || "[]"); } catch (e) { return []; } }
+    function writeAll(a) { try { localStorage.setItem(lsKey(room), JSON.stringify(a)); } catch (e) {} }
+    var listeners = [];
+    function emit() { var d = readAll(); listeners.forEach(function (fn) { fn(d); }); }
+    window.addEventListener("storage", function (e) { if (e.key === lsKey(room)) emit(); });
+    return {
+      mode: "local",
+      join: function (p) { var a = readAll(); var i = a.findIndex(function (x) { return x.id === p.id; }); if (i >= 0) a[i] = Object.assign(a[i], p); else a.push(p); writeAll(a); emit(); return Promise.resolve(); },
+      subscribe: function (cb) { cb(readAll()); listeners.push(cb); var iv = setInterval(function () { cb(readAll()); }, 2000); return function () { clearInterval(iv); }; }
+    };
+  }
+
+  function firebaseAdapter(room, cfg) {
+    return import(SDK + "firebase-app.js").then(function (appMod) {
+      return import(SDK + "firebase-firestore.js").then(function (fs) {
+        var app = appMod.initializeApp(cfg);
+        var db = fs.getFirestore(app);
+        return {
+          mode: "firebase",
+          join: function (p) { return fs.setDoc(fs.doc(db, "players", p.id), p, { merge: true }); },
+          subscribe: function (cb) {
+            var q = fs.query(fs.collection(db, "players"), fs.where("room", "==", room));
+            return fs.onSnapshot(q, function (snap) { var d = []; snap.forEach(function (doc) { d.push(doc.data()); }); cb(d); });
+          }
+        };
+      });
+    });
+  }
+
+  function init(room) {
+    room = room || "default";
+    var cfg = window.FIREBASE_CONFIG;
+    var configured = cfg && cfg.apiKey && cfg.apiKey.indexOf("PASTE") !== 0;
+    if (configured) {
+      return firebaseAdapter(room, cfg).catch(function (e) {
+        console.warn("[roster] Firebase unavailable, using local fallback:", e && e.message);
+        return localAdapter(room);
+      });
+    }
+    return Promise.resolve(localAdapter(room));
+  }
+
+  window.ZTDSRoster = { init: init };
+})();

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -556,9 +556,20 @@
   .pm-card h2{font-size:26px;font-weight:700;margin:6px 0 8px}
   .pm-sub{font-size:13.5px;color:var(--ink-soft);margin-bottom:16px}
   .pm-sub b{color:var(--ink)}
-  .pm-name{width:100%;border:1px solid var(--line);border-radius:10px;padding:11px 13px;font-family:"IBM Plex Sans",sans-serif;font-size:14px;color:var(--ink);margin-bottom:14px;outline:none}
-  .pm-name:focus{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.12)}
+  .pm-fields{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:6px}
+  .pm-field{display:flex;flex-direction:column;gap:4px}
+  .pm-field.pm-wide{grid-column:1 / -1}
+  .pm-field span{font-family:"IBM Plex Mono",monospace;font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint)}
+  .pm-field input{width:100%;border:1px solid var(--line);border-radius:10px;padding:10px 12px;font-family:"IBM Plex Sans",sans-serif;font-size:14px;color:var(--ink);outline:none}
+  .pm-field input:focus{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.12)}
+  .pm-field input.bad{border-color:var(--red);box-shadow:0 0 0 3px rgba(219,74,74,.12)}
+  .pm-error{font-size:12.5px;color:var(--red);background:var(--red-soft);border:1px solid #F0C4C4;border-radius:9px;padding:8px 11px;margin:4px 0 2px}
+  .pm-error[hidden]{display:none}
+  .pm-rolelbl{font-family:"IBM Plex Mono",monospace;font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint);margin:14px 0 8px}
   .pm-roles{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+  .pm-foot{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-top:14px}
+  .pm-proctor{font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--cyan-deep);text-decoration:none;white-space:nowrap}
+  .pm-proctor:hover{text-decoration:underline}
   .pm-role{
     text-align:left;border:1.5px solid var(--line);border-radius:12px;padding:13px 14px;cursor:pointer;
     background:#fff;transition:border-color .15s,box-shadow .15s,transform .05s;border-top:4px solid var(--rc,var(--line));
@@ -568,7 +579,7 @@
   .pm-role.facil{grid-column:1 / -1}
   .pm-role b{font-family:"Chakra Petch",sans-serif;font-size:16px;display:block;color:var(--ink)}
   .pm-role span{font-size:12px;color:var(--ink-soft)}
-  .pm-skip{display:block;width:100%;margin-top:14px;border:none;background:transparent;color:var(--ink-faint);font-family:"IBM Plex Mono",monospace;font-size:12px;cursor:pointer;padding:6px}
+  .pm-skip{border:none;background:transparent;color:var(--ink-faint);font-family:"IBM Plex Mono",monospace;font-size:12px;cursor:pointer;padding:6px 0}
   .pm-skip:hover{color:var(--ink-soft);text-decoration:underline}
 
   /* persona highlights across the page */
@@ -622,10 +633,19 @@
     <button class="pm-close" id="pmClose" aria-label="Close">&times;</button>
     <div class="pm-eyebrow">Join the sprint</div>
     <h2 id="pmTitle">Take your seat</h2>
-    <p class="pm-sub">Open this on your own device and pick the role you're playing. Your view then highlights what <b>you</b> do in every phase, on the board, and in the journey grid. Switch any time from the bar at the top.</p>
-    <input class="pm-name" id="pmName" type="text" placeholder="Your name or initials (optional)" maxlength="40" autocomplete="off">
+    <p class="pm-sub">Enter your details, your <b>team name</b>, and the role you're playing. Your view highlights what <b>you</b> do in every phase — and your team appears live on the proctor's roster. Switch any time from the bar at the top.</p>
+    <div class="pm-fields">
+      <label class="pm-field"><span>Your name</span><input id="pmName" type="text" placeholder="e.g. Sam Rivera" maxlength="60" autocomplete="name"></label>
+      <label class="pm-field"><span>Email</span><input id="pmEmail" type="email" placeholder="you@company.com" maxlength="120" autocomplete="email"></label>
+      <label class="pm-field pm-wide"><span>Team name</span><input id="pmTeam" type="text" placeholder="e.g. Blue Team" maxlength="60" autocomplete="off"></label>
+    </div>
+    <div class="pm-error" id="pmError" hidden></div>
+    <div class="pm-rolelbl">Pick your role</div>
     <div class="pm-roles" id="pmRoles"></div>
-    <button class="pm-skip" id="pmSkip">I'm just watching — skip for now</button>
+    <div class="pm-foot">
+      <button class="pm-skip" id="pmSkip">I'm just watching — skip for now</button>
+      <a class="pm-proctor" id="pmProctorLink" href="proctor.html">Proctor? Open the live roster &rarr;</a>
+    </div>
   </div>
 </div>
 
@@ -1704,6 +1724,8 @@
 </div>
 
 <!-- ============ INTERACTIVE ENGINE ============ -->
+<script src="firebase-config.js"></script>
+<script src="roster.js"></script>
 <script>
 (function(){
   "use strict";
@@ -2042,9 +2064,25 @@
     scribe:{label:"The Scribe", short:"Scribe", color:"#27A276", chip:"scr", col:4, card:"The Scribe", tag:"Owns the write-up · leads Document"},
     facilitator:{label:"Facilitator / Observer", short:"Facilitator", color:"#7E8CA1", chip:null, col:0, card:null, tag:"Runs the session — not an in-game seat"}
   };
-  var personaModal=$("#personaModal"), personaLabel=$("#personaLabel"), pmRoles=$("#pmRoles"), pmName=$("#pmName");
+  var personaModal=$("#personaModal"), personaLabel=$("#personaLabel"), pmRoles=$("#pmRoles");
+  var pmName=$("#pmName"), pmEmail=$("#pmEmail"), pmTeam=$("#pmTeam"), pmError=$("#pmError");
   var persona=null;
   try{ persona=JSON.parse(localStorage.getItem("ztds.persona")||"null"); }catch(e){}
+  function esc(s){ return String(s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
+
+  // shared cross-device roster (Firebase if configured, else single-device fallback)
+  var ROOM=(new URLSearchParams(location.search)).get("room") || "default";
+  var roster=null, playerId=null;
+  try{ playerId=localStorage.getItem("ztds.playerId"); }catch(e){}
+  if(!playerId){ playerId="p-"+Math.random().toString(36).slice(2,10)+Date.now().toString(36); try{ localStorage.setItem("ztds.playerId",playerId); }catch(e){} }
+  function rosterRecord(p){ var r=ROLES[p.role]||{}; return { id:playerId, room:ROOM, name:p.name||"", email:p.email||"", role:r.short||"", roleKey:p.role, teamName:p.team||"", joinedAt:p.joinedAt||Date.now() }; }
+  if(window.ZTDSRoster){
+    window.ZTDSRoster.init(ROOM).then(function(a){
+      roster=a;
+      if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.team){ try{ roster.join(rosterRecord(persona)); }catch(e){} }
+    });
+  }
+  var pl=$("#pmProctorLink"); if(pl) pl.href="proctor.html"+(ROOM!=="default"?("?room="+encodeURIComponent(ROOM)):"");
 
   // build role buttons
   Object.keys(ROLES).forEach(function(key){
@@ -2101,14 +2139,34 @@
       $("#btnPersona").querySelector(".dot").style.background="#7E8CA1";
     }
   }
-  function openPersona(){ pmName.value = persona && persona.name ? persona.name : ""; personaModal.hidden=false; setTimeout(function(){ pmName.focus(); },50); }
+  function showPmError(m){ pmError.textContent=m; pmError.hidden=false; }
+  function hidePmError(){ pmError.hidden=true; }
+  function openPersona(){
+    pmName.value = persona&&persona.name ? persona.name : "";
+    pmEmail.value = persona&&persona.email ? persona.email : "";
+    pmTeam.value = persona&&persona.team ? persona.team : "";
+    hidePmError();
+    [pmName,pmEmail,pmTeam].forEach(function(el){ el.classList.remove("bad"); });
+    personaModal.hidden=false; setTimeout(function(){ pmName.focus(); },50);
+  }
   function closePersona(){ personaModal.hidden=true; try{ localStorage.setItem("ztds.personaSeen","1"); }catch(e){} }
   function choosePersona(key){
-    persona={ role:key, name:(pmName.value||"").trim() };
+    var name=(pmName.value||"").trim(), email=(pmEmail.value||"").trim(), team=(pmTeam.value||"").trim();
+    var r=ROLES[key];
+    [pmName,pmEmail,pmTeam].forEach(function(el){ el.classList.remove("bad"); });
+    if(key!=="facilitator"){
+      var missing=[];
+      if(!name){ pmName.classList.add("bad"); missing.push("your name"); }
+      if(!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)){ pmEmail.classList.add("bad"); missing.push("a valid email"); }
+      if(!team){ pmTeam.classList.add("bad"); missing.push("a team name"); }
+      if(missing.length){ showPmError("Please enter "+missing.join(", ")+" to join a team — or choose Facilitator / Observer to skip."); return; }
+    }
+    hidePmError();
+    persona={ role:key, name:name, email:email, team:team, joinedAt:Date.now() };
     try{ localStorage.setItem("ztds.persona", JSON.stringify(persona)); }catch(e){}
     applyPersona(); closePersona();
-    var r=ROLES[key];
-    toast("Seat taken", (persona.name?persona.name+", you":"You")+" are <b>"+r.label+"</b> — "+r.tag+".", "phase");
+    if(roster && key!=="facilitator"){ try{ roster.join(rosterRecord(persona)); }catch(e){} }
+    toast("Seat taken", (name?esc(name)+", you":"You")+" are <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+".", "phase");
   }
   $("#btnPersona").addEventListener("click", openPersona);
   $("#pmClose").addEventListener("click", closePersona);


### PR DESCRIPTION
## Summary

Adds participant **registration** and a **live proctor roster** to the Zero Trust Agentic Design Sprint activity. Each participant enters their **name, email, and team name** when taking a seat, and the proctor sees every team and member live on a dedicated page.

## Changes

- **Participant page** (`zero-trust-design-sprint.html`): the "take your seat" modal now collects name, email, and team name alongside the role, with inline validation. Facilitator/Observer can still skip. A confirmed seat publishes the participant to the shared roster.
- **`proctor.html`** (new): live roster grouped by team, showing each member's name, email, role, and join time, plus team/player counts and **CSV export**.
- **`roster.js`** (new): adapter that uses **Firebase Firestore** for real cross-device sync when configured, and transparently **falls back to single-device localStorage** otherwise.
- **`firebase-config.js`** (new): placeholder config with step-by-step setup and suggested Firestore security rules.
- Optional **`?room=CODE`** scopes a roster to one session across both pages.
- **README** documents the two pages, optional Firebase setup, and the PII note.

## Architecture note

GitHub Pages is static, so cross-device sharing needs a backend. Firebase (client SDK, free tier) provides it with no server to run; until it's configured the pages work in single-device mode so nothing breaks. The roster stores participant **emails (PII)** — the included Firestore rules restrict deletes, and the README advises clearing data after a session.

## Testing

Verified end to end in headless Chromium: incomplete/invalid joins are blocked (bad email flagged, modal stays open, nothing written); valid joins register with all fields; two teammates group under one team; the proctor page renders them live with correct roles, emails, and counts. Existing timer, persona highlighting, injection reveals, checklists, and solution sheet continue to work. No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_