### PR TITLE
Add SETUP.md setup & verification checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Participants enter their **name, email, and team name** when they take a seat, a
 - Optional `?room=CODE` on both pages scopes a roster to one session (handy when running several clinics).
 - Note: the roster stores participant **emails (PII)** — use the provided Firestore rules and clear the data after your session.
 
+📋 **Full step-by-step setup, verification, and privacy checklist: [`SETUP.md`](./SETUP.md)**
+
 ---
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,102 @@
+# Setup & Verification — Zero Trust Agentic Design Sprint
+
+Everything you need to run the interactive activity, enable the live cross-device
+roster, and confirm it works. The activity **works without Firebase** (single-device
+mode); Firebase only adds the shared, cross-device proctor roster.
+
+- **Participant page:** `zero-trust-design-sprint.html`
+- **Proctor roster:** `proctor.html`
+- **Config file:** `firebase-config.js`
+
+---
+
+## 1. Publish the pages (GitHub Pages)
+
+1. Repo **Settings → Pages**.
+2. **Source:** "Deploy from a branch" → **Branch:** `master` → folder `/ (root)` → **Save**.
+3. After ~1 minute the pages are live at:
+   - Participant: `https://coolmukky.github.io/github-slideshow/zero-trust-design-sprint.html`
+   - Proctor: `https://coolmukky.github.io/github-slideshow/proctor.html`
+
+> Instant preview without Pages:
+> `https://htmlpreview.github.io/?https://github.com/coolmukky/github-slideshow/blob/master/zero-trust-design-sprint.html`
+
+---
+
+## 2. Firebase — live cross-device roster (optional but recommended)
+
+Skip this and everything still works in **single-device mode** (the proctor only sees
+people who joined on the proctor's own browser). Do this to see all participants across
+all their devices.
+
+### 2a. Create the project & web app  ✅ *(done)*
+- Firebase Console → **Add project** → add a **Web app (`</>`)** → copy the `firebaseConfig`.
+- Those values are already in [`firebase-config.js`](./firebase-config.js) for project `design-clinic-58ad0`.
+- Firebase web config values are **public by design** — security comes from the Firestore rules below, not from hiding them.
+
+### 2b. Create the Firestore database  ⬜ *(required)*
+- Console → **Build → Firestore Database → Create database**.
+- Mode: **Production**. Location: **`nam5` (United States)** — best for a mostly-US, global audience.
+
+### 2c. Publish the security rules  ⬜ *(required)*
+Firestore → **Rules** tab → paste and **Publish**:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /players/{id} {
+      allow read: if true;
+      allow create, update: if
+        request.resource.data.name is string &&
+        request.resource.data.name.size() < 120 &&
+        request.resource.data.email.size() < 200 &&
+        request.resource.data.teamName.size() < 120;
+      allow delete: if false;
+    }
+  }
+}
+```
+
+Allows participants to register and the proctor to read; blocks client-side deletes; caps
+field sizes. **Do not leave Firestore in open "test mode"** — that exposes participant emails.
+
+### 2d. (Optional) Restrict the API key — defense-in-depth  ⬜
+Google Cloud Console → **APIs & Services → Credentials** → project `design-clinic-58ad0` →
+open **"Browser key (auto created by Firebase)"**:
+
+- **Application restrictions → HTTP referrers**, add:
+  - `https://coolmukky.github.io/*`
+  - `http://localhost:*/*` (optional, local testing)
+- **API restrictions → Restrict key**, select: **Cloud Firestore API**, **Firebase Installations API**, **Identity Toolkit API**.
+- **Save.** Allow ~5 minutes to propagate. If the roster breaks afterward, set API restrictions back to "Don't restrict key" (keep the referrer restriction) and re-check the referrer matches your URL exactly.
+
+---
+
+## 3. Verify it's live
+
+1. Open the **participant page** and **Take your seat** (name, email, team, role).
+2. On a **different device/browser**, open **`proctor.html`**.
+3. Top-left status should read **"Live · Firebase"** (green dot) — not "Single-device (local)".
+4. Your entry appears under its team; a second person on another device appears too.
+
+Troubleshooting:
+- Status is "Live" but nothing shows → check **2c rules** and that **2b** database exists.
+- Status stuck on "Single-device (local)" → the SDK couldn't load; check the browser console and that `firebase-config.js` has real values (no `PASTE…`).
+
+---
+
+## 4. Running a session
+
+- **Multiple rooms/cohorts:** add `?room=CODE` to *both* page URLs to scope a roster to one
+  session, e.g. `…/proctor.html?room=june-cohort` and `…/zero-trust-design-sprint.html?room=june-cohort`.
+- **Facilitator timer:** the control bar drives the 60-minute clock, phase highlighting, and
+  timed injection reveals; the proctor page is a separate live roster.
+- **Reports:** on `proctor.html`, use **Export CSV** for raw data or **Report** for a printable
+  (PDF-ready) participant summary with per-team completeness. Scales to ~300 participants.
+
+## 5. Privacy / after the session
+
+The roster stores participant **names and emails (PII)**. When a cohort is done, delete its
+records in the Firestore console (**Firestore → Data →** `players` collection). Client-side
+deletes are disabled by the rules, so removal is done from the console.


### PR DESCRIPTION
## Summary

Adds `SETUP.md` — a single, step-by-step checklist for running the activity and enabling the live roster, and links it from the README.

## Contents

1. **Publish the pages** (GitHub Pages) with the exact URLs.
2. **Firebase** — create the project/web app (done), **create Firestore**, **publish security rules**, and optional **API-key restriction** (defense-in-depth).
3. **Verify it's live** — the participant → proctor "Live · Firebase" check, with troubleshooting.
4. **Running a session** — `?room=CODE` scoping, the facilitator timer, and CSV / printable report.
5. **Privacy** — the roster stores names + emails (PII); how to delete records after a cohort.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_