### PR TITLE
Add PRE-READ.md participant primer

### DIFF
--- a/PRE-READ.md
+++ b/PRE-READ.md
@@ -1,0 +1,45 @@
+# Before you join — 2-minute pre-read
+
+Skim this **before** the session so you arrive ready and the team can hit the ground running.
+(The full playbook is on the participant page; you don't need to read it in advance.)
+
+## What it is
+A **timed, 60-minute, four-person tabletop exercise.** Your team reads a short breach
+scenario and designs a **Zero Trust architecture for autonomous AI agents** — producing one
+labelled diagram and one solution sheet before the clock hits zero. It's a learning exercise,
+not a competition.
+
+## Your goal
+Take a company drowning in over-privileged AI agents and redesign it so every agent has its
+own identity, only the access it needs, a checkpoint on every action, and a full audit trail.
+
+## Pick a role (you'll choose at the start)
+- **Conductor** — owns the clock; keeps the team on pace.
+- **Critic** — challenges decisions: "what would make this fail?"
+- **Architect** — draws the topology diagram.
+- **Scribe** — writes the one-page solution sheet.
+
+*(Teams of 3 or 5 adapt — the facilitator will say how.)*
+
+## The hour at a glance
+`Brief-In → Expose → Decide → Design → Document → Submit` — six phases, hard time stops, with
+three surprise "injections" revealed along the way that make you adapt on the fly.
+
+## Six ideas you'll use (the quick primer)
+So the topic isn't cold, these are the Zero Trust controls a strong design applies to AI agents:
+
+1. **Per-agent identity** — each agent has its own identity; no shared accounts.
+2. **Least privilege, just-in-time** — short-lived, narrowly-scoped tokens per action.
+3. **Verify every call** — a policy checkpoint authorizes each agent→resource request (deny by default).
+4. **Contain the blast radius** — microsegmentation so one compromised agent can't roam.
+5. **Human-in-the-loop** — a person approves the riskiest actions (refunds, freezes, prod writes).
+6. **Audit everything** — an immutable, identity-bound log of every action.
+
+Don't worry about mastering these — the exercise is about applying and defending them as a team.
+
+## To join (takes 30 seconds)
+1. Open the participant link your facilitator shares.
+2. Click **Take your seat** → enter your **name, email, team name**, and pick your **role**.
+3. That's it — the facilitator starts the clock.
+
+See you there. 🚀

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Participants enter their **name, email, and team name** when they take a seat, a
 
 📋 **Full step-by-step setup, verification, and privacy checklist: [`SETUP.md`](./SETUP.md)**
 🎤 **Running a session? Facilitator run-sheet: [`FACILITATOR.md`](./FACILITATOR.md)**
+📨 **Send participants ahead of time: [`PRE-READ.md`](./PRE-READ.md)** — a 2-minute primer so they arrive oriented.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `PRE-READ.md` — a ~2-minute primer to send participants **before** the session so they arrive oriented, which helps teams stay inside the 60 minutes. Linked from the README.

## Contents

- What the activity is (60-min, four-person, Zero Trust for AI agents)
- The goal, the four roles, and the six phases at a glance
- A quick primer on the six Zero Trust controls they'll apply (so the topic isn't cold)
- 30-second join steps (Take your seat → name/email/team/role)

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_