### PR TITLE
Add scoring, proctor evaluation, and live leaderboard

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -38,8 +38,9 @@ the in-session phase/time cues live on the participant page itself.)
 
 ## After the clock (10 min)
 
-- [ ] Teams submit their diagram + solution sheet per the activity.
-- [ ] On **proctor**, click **Report** → **Print / Save as PDF** for a per-team participant record, or **Export CSV** for raw data.
+- [ ] Teams fill the solution sheet and click **Submit for scoring** (each team submits once; the last submit wins).
+- [ ] On **proctor**, each submitted team shows an **Evaluate** button → open it to read their solution and score **3 injections (10 each) + final solution (70) = 100**. Scores appear live on **`leaderboard.html`** (project it).
+- [ ] On **proctor**, click **Report** → **Print / Save as PDF** for a per-team record (now includes scores), or **Export CSV** for raw data.
 - [ ] Run the 10-minute debrief (reference design is in the participant page's Debrief section).
 
 ## Cleanup (privacy)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ An interactive playbook for running the **Zero Trust Agentic Design Sprint** des
 **Pages**
 
 - ➡️ **[Participant page — `zero-trust-design-sprint.html`](./zero-trust-design-sprint.html)** — the playbook each participant opens (served at `/zero-trust-design-sprint.html`). A **Focus view** toggle hides reference sections during the hour so teams stay on task.
-- 👁️ **[Proctor roster — `proctor.html`](./proctor.html)** — live view of all teams and members as they join, with per-role counts, team-completeness flags, a search filter, **CSV export**, and a printable **participant report** (PDF-ready). Scales comfortably to ~300 participants.
+- 👁️ **[Proctor roster & evaluation — `proctor.html`](./proctor.html)** — live view of all teams and members as they join, with per-role counts, team-completeness flags, a search filter, **CSV export**, and a printable **participant report** (PDF-ready). Also lets the proctor open each team's **submitted solution and score it** (3 injections + final solution = 100). Scales comfortably to ~300 participants.
+- 🏆 **[Leaderboard — `leaderboard.html`](./leaderboard.html)** — live team rankings by score; project it on the shared screen.
 
 **Live cross-device roster (optional setup)**
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -5,7 +5,8 @@ roster, and confirm it works. The activity **works without Firebase** (single-de
 mode); Firebase only adds the shared, cross-device proctor roster.
 
 - **Participant page:** `zero-trust-design-sprint.html`
-- **Proctor roster:** `proctor.html`
+- **Proctor roster & evaluation:** `proctor.html`
+- **Leaderboard:** `leaderboard.html`
 - **Config file:** `firebase-config.js`
 
 ---
@@ -54,12 +55,29 @@ service cloud.firestore {
         request.resource.data.teamName.size() < 120;
       allow delete: if false;
     }
+    match /solutions/{id} {
+      allow read: if true;
+      allow create, update: if
+        request.resource.data.teamName is string &&
+        request.resource.data.teamName.size() < 120;
+      allow delete: if false;
+    }
+    match /scores/{id} {
+      allow read: if true;
+      allow create, update: if
+        request.resource.data.teamName is string &&
+        request.resource.data.total is number;
+      allow delete: if false;
+    }
   }
 }
 ```
 
-Allows participants to register and the proctor to read; blocks client-side deletes; caps
-field sizes. **Do not leave Firestore in open "test mode"** — that exposes participant emails.
+Covers three collections: `players` (roster), `solutions` (submitted design sheets), and
+`scores` (proctor evaluations). Allows registering/submitting/scoring and reading; blocks
+client-side deletes. **Do not leave Firestore in open "test mode"** — that exposes participant
+emails. **If you published an earlier players-only version of these rules, re-publish this one**
+or solution submissions and scores will be rejected.
 
 ### 2d. (Optional) Restrict the API key — defense-in-depth  ⬜
 Google Cloud Console → **APIs & Services → Credentials** → project `design-clinic-58ad0` →
@@ -94,6 +112,11 @@ Troubleshooting:
   timed injection reveals; the proctor page is a separate live roster.
 - **Reports:** on `proctor.html`, use **Export CSV** for raw data or **Report** for a printable
   (PDF-ready) participant summary with per-team completeness. Scales to ~300 participants.
+- **Scoring & leaderboard:** teams click **Submit for scoring** on the participant page (after
+  taking a seat with a team). On `proctor.html`, each submitted team shows an **Evaluate** button —
+  open it to read their solution and score 3 injections (10 each) + final solution (70) = 100.
+  Scores rank teams live on **`leaderboard.html`** (project it on the shared screen). Evaluation is
+  manual by the proctor. *(AI-agent evaluation is not enabled in this version.)*
 
 ## 5. Privacy / after the session
 

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -18,6 +18,7 @@
       records contain participant emails (PII).
 
         rules_version = '2';
+        rules_version = '2';
         service cloud.firestore {
           match /databases/{database}/documents {
             match /players/{id} {
@@ -27,6 +28,20 @@
                 request.resource.data.name.size() < 120 &&
                 request.resource.data.email.size() < 200 &&
                 request.resource.data.teamName.size() < 120;
+              allow delete: if false;
+            }
+            match /solutions/{id} {
+              allow read: if true;
+              allow create, update: if
+                request.resource.data.teamName is string &&
+                request.resource.data.teamName.size() < 120;
+              allow delete: if false;
+            }
+            match /scores/{id} {
+              allow read: if true;
+              allow create, update: if
+                request.resource.data.teamName is string &&
+                request.resource.data.total is number;
               allow delete: if false;
             }
           }

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Leaderboard — Zero Trust Agentic Design Sprint</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --surface:#FFFFFF;--ink:#0E1A2B;--ink-soft:#46566E;--ink-faint:#7E8CA1;
+    --line:#CBD5E3;--line-soft:#E1E8F1;--navy:#122A47;--navy-deep:#0A1830;
+    --cyan:#0FA9BE;--cyan-deep:#0A7C8C;--amber:#E2891F;--red:#DB4A4A;--green:#27A276;
+    --gold:#E9B949;--silver:#AEB6C2;--bronze:#C88A5B;
+    --shadow:0 1px 0 rgba(14,26,43,.04), 0 18px 40px -28px rgba(14,26,43,.55);
+  }
+  *{box-sizing:border-box}
+  body{margin:0;font-family:"IBM Plex Sans",system-ui,sans-serif;color:var(--ink);background:#F3F6FA;-webkit-font-smoothing:antialiased}
+  h1,h2,h3{font-family:"Chakra Petch",sans-serif;margin:0;line-height:1.1}
+  .wrap{max-width:900px;margin:0 auto;padding:0 22px}
+  .top{background:radial-gradient(120% 160% at 88% -20%,#1c3a5e 0%,var(--navy) 45%,var(--navy-deep) 100%);color:#EAF1F8;border-bottom:3px solid var(--cyan)}
+  .top-in{padding:26px 0 24px;display:flex;flex-wrap:wrap;align-items:flex-end;gap:16px}
+  .eyebrow{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:500;letter-spacing:.22em;text-transform:uppercase;color:#7FE2EF}
+  .top h1{font-size:clamp(26px,4.5vw,42px);font-weight:700;color:#fff;margin:.25em 0 .1em}
+  .top .sub{color:#AEC4DC;font-size:14px}
+  .top .spacer{flex:1}
+  .status{display:inline-flex;align-items:center;gap:8px;font-family:"IBM Plex Mono",monospace;font-size:12px;color:#AEC4DC}
+  .status .dot{width:9px;height:9px;border-radius:50%;background:#7E8CA1}
+  .status.live .dot{background:var(--green);box-shadow:0 0 0 3px rgba(39,162,118,.25);animation:pulse 1.4s infinite}
+  .status.local .dot{background:var(--amber)}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.3}}
+
+  .board{margin:22px 0 40px;display:flex;flex-direction:column;gap:10px}
+  .row{display:flex;align-items:center;gap:16px;background:var(--surface);border:1px solid var(--line);border-radius:14px;padding:14px 18px;box-shadow:var(--shadow);border-left:6px solid var(--line)}
+  .row.r1{border-left-color:var(--gold)}
+  .row.r2{border-left-color:var(--silver)}
+  .row.r3{border-left-color:var(--bronze)}
+  .rank{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:26px;color:var(--ink-faint);min-width:44px;text-align:center}
+  .row.r1 .rank,.row.r2 .rank,.row.r3 .rank{color:var(--ink)}
+  .medal{font-size:24px;min-width:44px;text-align:center}
+  .team{flex:1;min-width:0}
+  .team .nm{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:19px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .team .bd{font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--ink-faint);margin-top:2px}
+  .bars{display:flex;gap:3px;margin-top:7px;max-width:320px}
+  .bars i{height:6px;border-radius:3px;background:var(--line-soft)}
+  .bars i.f{background:var(--cyan)}
+  .total{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:30px;color:var(--ink);white-space:nowrap}
+  .total small{font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;color:var(--ink-faint)}
+
+  .empty{margin:56px auto;max-width:520px;text-align:center;color:var(--ink-soft)}
+  .empty svg{width:46px;height:46px;color:var(--ink-faint);margin-bottom:12px}
+  .empty h3{font-size:18px;margin-bottom:6px;color:var(--ink)}
+  .note{font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--ink-faint);text-align:center;margin-top:6px}
+  .foot{margin:26px 0;text-align:center;font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--ink-faint)}
+  .foot a{color:var(--cyan-deep)}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="wrap top-in">
+    <div>
+      <span class="eyebrow">Zero Trust Agentic Design Sprint</span>
+      <h1>🏆 Leaderboard</h1>
+      <div class="sub">Team scores — 3 injections (10 each) + final solution (70) = 100. Updates live.</div>
+    </div>
+    <div class="spacer"></div>
+    <span class="status" id="status"><span class="dot"></span><span id="statusText">Connecting…</span></span>
+  </div>
+</header>
+
+<div class="wrap">
+  <div class="board" id="board"></div>
+  <div class="empty" id="empty" hidden>
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M6 21V10M12 21V4M18 21v-7"/></svg>
+    <h3>No scores yet</h3>
+    <p>Teams appear here as the proctor evaluates them. Scores update automatically.</p>
+  </div>
+  <div class="note" id="pending" hidden></div>
+  <div class="foot">Room: <b id="footRoom">default</b> · <a href="proctor.html">Proctor view →</a></div>
+</div>
+
+<script src="firebase-config.js"></script>
+<script src="roster.js"></script>
+<script>
+(function(){
+  "use strict";
+  var $=function(s){return document.querySelector(s);};
+  var ROOM=(new URLSearchParams(location.search)).get("room")||"default";
+  $("#footRoom").textContent=ROOM;
+  var scores={}, solutions={};
+  function esc(s){ return String(s==null?"":s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
+  function tkey(t){ return (t==null?"":String(t)).trim().toLowerCase(); }
+  var MEDALS={1:"🥇",2:"🥈",3:"🥉"};
+
+  function bars(n,max){ var out=""; for(var i=0;i<max;i++){ out+='<i class="'+(i<n?'f':'')+'" style="flex:1"></i>'; } return out; }
+
+  function render(){
+    var list=Object.keys(scores).map(function(k){ return scores[k]; });
+    list.sort(function(a,b){ return (b.total||0)-(a.total||0) || String(a.teamName||"").localeCompare(String(b.teamName||"")); });
+    var board=$("#board");
+    if(!list.length){ board.innerHTML=""; $("#empty").hidden=false; $("#pending").hidden=true; return; }
+    $("#empty").hidden=true;
+    board.innerHTML=list.map(function(s,i){
+      var rank=i+1;
+      var head = MEDALS[rank] ? ('<div class="medal">'+MEDALS[rank]+'</div>') : ('<div class="rank">'+rank+'</div>');
+      return '<div class="row r'+rank+'">'+head+
+        '<div class="team"><div class="nm">'+esc(s.teamName||"—")+'</div>'+
+          '<div class="bd">Injections '+(s.i1||0)+' / '+(s.i2||0)+' / '+(s.i3||0)+'  ·  Solution '+(s.solution||0)+' / 70</div>'+
+          '<div class="bars">'+bars((s.i1||0)+(s.i2||0)+(s.i3||0),30)+'</div>'+
+        '</div>'+
+        '<div class="total">'+(s.total||0)+'<small> / 100</small></div>'+
+      '</div>';
+    }).join("");
+    // pending (submitted but not scored)
+    var pend=0; Object.keys(solutions).forEach(function(k){ if(!scores[k]) pend++; });
+    if(pend){ $("#pending").hidden=false; $("#pending").textContent=pend+" team"+(pend===1?"":"s")+" submitted and awaiting scoring."; }
+    else { $("#pending").hidden=true; }
+  }
+
+  render();
+  if(window.ZTDSRoster){
+    window.ZTDSRoster.init(ROOM).then(function(adapter){
+      var live=adapter.mode==="firebase";
+      $("#status").className="status "+(live?"live":"local");
+      $("#statusText").textContent=live?"Live · Firebase":"Single-device (local)";
+      adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[tkey(s.teamName)]=s; }); render(); });
+    });
+  } else { $("#statusText").textContent="Leaderboard unavailable"; }
+})();
+</script>
+</body>
+</html>

--- a/proctor.html
+++ b/proctor.html
@@ -86,6 +86,43 @@
   .empty code{font-family:"IBM Plex Mono",monospace;background:#EEF3F9;border:1px solid var(--line-soft);border-radius:6px;padding:2px 7px;font-size:12.5px}
   .foot{margin:30px 0;color:var(--ink-faint);font-family:"IBM Plex Mono",monospace;font-size:11px;text-align:center}
   .foot a{color:var(--cyan-deep)}
+
+  /* score footer on team cards */
+  .score-row{display:flex;align-items:center;gap:9px;padding:10px 16px;border-top:1px solid var(--line-soft);background:#FAFCFF;flex-wrap:wrap}
+  .score-row.muted{color:var(--ink-faint);font-family:"IBM Plex Mono",monospace;font-size:12px}
+  .sub-badge{font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:#1f6e52;background:var(--green-soft,#D7F0E6);border:1px solid #A9DEC9;border-radius:20px;padding:3px 9px}
+  .score-big{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:16px;color:var(--ink)}
+  .score-big small{font-family:"IBM Plex Mono",monospace;font-weight:600;font-size:11px;color:var(--ink-faint)}
+  .rank-badge{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:700;color:#fff;background:var(--navy);border-radius:20px;padding:3px 9px}
+  .mini-btn{margin-left:auto;font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;color:#fff;background:var(--cyan-deep);border:none;border-radius:8px;padding:6px 12px;cursor:pointer}
+  .mini-btn:hover{background:#0a6c7a}
+  .mini-btn.re{background:#fff;color:var(--cyan-deep);border:1px solid var(--cyan)}
+
+  /* evaluate modal */
+  .eval-modal{position:fixed;inset:0;z-index:300;display:flex;align-items:center;justify-content:center;padding:18px;background:rgba(8,18,34,.72)}
+  .eval-modal[hidden]{display:none}
+  .em-card{position:relative;width:min(920px,100%);max-height:92vh;overflow:auto;background:var(--surface);border-radius:16px;padding:22px 24px;box-shadow:0 30px 70px -20px rgba(0,0,0,.6);border-top:4px solid var(--cyan)}
+  .em-close{position:absolute;top:12px;right:15px;border:none;background:transparent;font-size:24px;color:var(--ink-faint);cursor:pointer}
+  .em-eyebrow{font-family:"IBM Plex Mono",monospace;font-size:11px;letter-spacing:.2em;text-transform:uppercase;color:var(--cyan-deep)}
+  .em-card h2{font-size:22px;margin:4px 0 2px}
+  .em-meta{font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--ink-faint);margin-bottom:14px}
+  .em-cols{display:grid;grid-template-columns:1.2fr .9fr;gap:18px}
+  .em-field{border:1px solid var(--line-soft);border-radius:10px;padding:10px 12px;margin-bottom:9px}
+  .em-field .k{font-family:"IBM Plex Mono",monospace;font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--cyan-deep);margin-bottom:4px}
+  .em-field .v{font-size:13px;color:var(--ink);white-space:pre-wrap;word-break:break-word}
+  .em-field .v.empty{color:var(--ink-faint);font-style:italic}
+  .em-score{background:#F7F9FC;border:1px solid var(--line-soft);border-radius:12px;padding:14px}
+  .em-score h3{font-size:14px;margin:0 0 10px}
+  .em-score label{display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:13px;color:var(--ink-soft);margin-bottom:9px}
+  .em-score input[type=number]{width:70px;border:1px solid var(--line);border-radius:8px;padding:6px 8px;font-family:"IBM Plex Mono",monospace;font-size:13px;text-align:right;outline:none}
+  .em-score input:focus{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.12)}
+  .em-sol{flex-direction:column;align-items:stretch !important}
+  .em-sol .r{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:5px}
+  .em-total{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:18px;margin:6px 0 12px;padding-top:10px;border-top:1px dashed var(--line)}
+  .em-notes{flex-direction:column;align-items:stretch !important}
+  .em-notes textarea{width:100%;border:1px solid var(--line);border-radius:8px;padding:8px;font-family:"IBM Plex Sans",sans-serif;font-size:13px;min-height:56px;resize:vertical;outline:none;margin-top:5px}
+  .em-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:6px}
+  @media (max-width:720px){ .em-cols{grid-template-columns:1fr} }
 </style>
 </head>
 <body>
@@ -112,7 +149,8 @@
     <span class="spacer"></span>
     <button class="btn" id="btnRefresh" title="Reload"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4v6h6"/><path d="M4 10a8 8 0 113 8"/></svg>Reload</button>
     <button class="btn" id="btnCsv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M5 21h14"/></svg>Export CSV</button>
-    <button class="btn primary" id="btnReport"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 3h9l5 5v13H6z"/><path d="M14 3v6h6"/><path d="M9 13h7M9 17h7"/></svg>Report</button>
+    <button class="btn" id="btnReport"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 3h9l5 5v13H6z"/><path d="M14 3v6h6"/><path d="M9 13h7M9 17h7"/></svg>Report</button>
+    <a class="btn primary" id="btnLeaderboard" href="leaderboard.html"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 21V10M12 21V4M18 21v-7"/></svg>Leaderboard</a>
   </div>
   <div class="notice" id="localNotice" hidden>
     <b>Single-device mode.</b> Firebase isn't configured, so this roster only shows people who joined <b>on this device/browser</b>. To see every participant's device live, fill in <code>firebase-config.js</code> (setup steps are in that file).
@@ -130,6 +168,34 @@
   <div class="foot">Roster room: <b id="footRoom">default</b> · <a href="zero-trust-design-sprint.html">← Back to the participant page</a></div>
 </div>
 
+<!-- evaluate modal -->
+<div class="eval-modal" id="evalModal" hidden role="dialog" aria-modal="true" aria-labelledby="emTeam">
+  <div class="em-card">
+    <button class="em-close" id="emClose" aria-label="Close">&times;</button>
+    <div class="em-eyebrow">Evaluate solution</div>
+    <h2 id="emTeam">Team</h2>
+    <div class="em-meta" id="emMeta"></div>
+    <div class="em-cols">
+      <div id="emSolution"></div>
+      <div class="em-score">
+        <h3>Score</h3>
+        <label>Injection 01 — Autonomous Expansion <input type="number" min="0" max="10" step="1" id="emI1"> <span>/ 10</span></label>
+        <label>Injection 02 — Token in the Wild <input type="number" min="0" max="10" step="1" id="emI2"> <span>/ 10</span></label>
+        <label>Injection 03 — Prove It <input type="number" min="0" max="10" step="1" id="emI3"> <span>/ 10</span></label>
+        <label class="em-sol">Final solution — completion &amp; best-practice controls (8 reference controls, coherence)
+          <span class="r"><input type="number" min="0" max="70" step="1" id="emSol"> <span>/ 70</span></span>
+        </label>
+        <div class="em-total">Total: <span id="emTotal">0</span> / 100</div>
+        <label class="em-notes">Notes (optional)<textarea id="emNotes" placeholder="What was strong / missing…"></textarea></label>
+        <div class="em-actions">
+          <button class="btn" id="emCancel">Cancel</button>
+          <button class="btn primary" id="emSave">Save score</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="firebase-config.js"></script>
 <script src="roster.js"></script>
 <script>
@@ -141,7 +207,20 @@
   var ROOM = (new URLSearchParams(location.search)).get("room") || "default";
   $("#roomInput").value = ROOM;
   $("#footRoom").textContent = ROOM;
+  $("#btnLeaderboard").href = "leaderboard.html" + (ROOM!=="default" ? ("?room="+encodeURIComponent(ROOM)) : "");
   var latest = [];
+  var solutions = {};   // teamKey -> solution doc
+  var scores = {};      // teamKey -> score doc
+  var ranks = {};       // teamKey -> rank (1-based, scored teams only)
+  var MAX_INJ = 10, MAX_SOL = 70;
+  function tkey(t){ return (t==null?"":String(t)).trim().toLowerCase(); }
+  function clampNum(v, max){ v = parseInt(v,10); if(isNaN(v)||v<0) v=0; if(v>max) v=max; return v; }
+  function computeRanks(){
+    ranks = {};
+    var scored = Object.keys(scores).map(function(k){ return { k:k, total:scores[k].total||0 }; });
+    scored.sort(function(a,b){ return b.total-a.total; });
+    scored.forEach(function(s,i){ ranks[s.k] = i+1; });
+  }
 
   function esc(s){ return String(s==null?"":s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
   function fmtTime(ms){ if(!ms) return ""; var d=new Date(ms); var h=d.getHours(), m=d.getMinutes(); return (h<10?"0":"")+h+":"+(m<10?"0":"")+m; }
@@ -166,11 +245,12 @@
   function sortMembers(members){ members.sort(function(a,b){ var oa=ROLE_ORDER[a.roleKey]!=null?ROLE_ORDER[a.roleKey]:9, ob=ROLE_ORDER[b.roleKey]!=null?ROLE_ORDER[b.roleKey]:9; return oa-ob || (a.joinedAt||0)-(b.joinedAt||0); }); return members; }
   function matches(p,q){ if(!q) return true; return [p.name,p.email,p.teamName,p.role].some(function(v){ return String(v||"").toLowerCase().indexOf(q)>=0; }); }
 
-  function render(players){
-    latest = players || [];
+  function render(){
+    computeRanks();
     var all = groupBy(latest);
     var completeCount = all.order.filter(function(k){ return isComplete(all.groups[k].members); }).length;
     var roleCounts = {}; latest.forEach(function(p){ roleCounts[p.roleKey]=(roleCounts[p.roleKey]||0)+1; });
+    var submittedCount = Object.keys(solutions).length, scoredCount = Object.keys(scores).length;
 
     $("#statTeams").textContent = all.order.length;
     $("#statPlayers").textContent = latest.length;
@@ -183,6 +263,7 @@
         pills += '<span class="pill"><span class="sw" style="background:'+ROLE_COLORS[rk]+'"></span>'+ROLE_LABELS[rk]+' '+(roleCounts[rk]||0)+'</span>';
       });
       pills += '<span class="pill '+(completeCount===all.order.length&&all.order.length?'ok':'warn')+'">'+completeCount+' / '+all.order.length+' teams complete</span>';
+      pills += '<span class="pill">Submitted '+submittedCount+'</span><span class="pill '+(scoredCount?'ok':'')+'">Scored '+scoredCount+'</span>';
       summary.innerHTML = pills;
     } else { summary.hidden=true; }
 
@@ -212,7 +293,23 @@
         '</div>';
       }).join("");
       var missHtml = missing.length ? '<div class="miss">Missing: <b>'+missing.join(", ")+'</b></div>' : '';
-      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+rows+missHtml+'</div>';
+      // score / evaluate footer
+      var tk = key; // group key is the lowercased team name
+      var sol = solutions[tk], sc = scores[tk];
+      var footer;
+      if(sc){
+        footer = '<div class="score-row">'+
+          (ranks[tk] ? '<span class="rank-badge">#'+ranks[tk]+'</span>' : '')+
+          '<span class="score-big">'+sc.total+'<small> / 100</small></span>'+
+          '<span class="sub-badge">i '+(sc.i1||0)+'/'+(sc.i2||0)+'/'+(sc.i3||0)+' · sol '+(sc.solution||0)+'</span>'+
+          '<button class="mini-btn re" data-eval="'+esc(tk)+'">Re-evaluate</button></div>';
+      } else if(sol){
+        footer = '<div class="score-row"><span class="sub-badge">Submitted '+fmtTime(sol.submittedAt)+'</span>'+
+          '<button class="mini-btn" data-eval="'+esc(tk)+'">Evaluate</button></div>';
+      } else {
+        footer = '<div class="score-row muted">No solution submitted yet</div>';
+      }
+      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+rows+missHtml+footer+'</div>';
     }).join("");
   }
 
@@ -238,7 +335,7 @@
 
   // live filter
   var fEl = $("#filterInput");
-  fEl.addEventListener("input", function(){ filterText = fEl.value||""; render(latest); });
+  fEl.addEventListener("input", function(){ filterText = fEl.value||""; render(); });
 
   // ---------- printable participant report ----------
   function fmtDateTime(ms){ var d=new Date(ms); return d.toLocaleString(); }
@@ -253,7 +350,9 @@
       var mem = g.members.map(function(p){
         return '<tr><td>'+esc(p.role||"—")+'</td><td>'+esc(p.name||"—")+'</td><td>'+esc(p.email||"")+'</td><td>'+fmtTime(p.joinedAt)+'</td></tr>';
       }).join("");
-      return '<div class="rt"><h3>'+esc(g.name)+' <span class="'+(missing.length?"bad":"ok")+'">'+(missing.length?("incomplete — missing "+missing.join(", ")):"complete")+'</span></h3>'+
+      var sc=scores[key];
+      var scoreSpan = sc ? ' <span class="score">'+sc.total+'/100'+(ranks[key]?' · #'+ranks[key]:'')+'</span>' : '';
+      return '<div class="rt"><h3>'+esc(g.name)+' <span class="'+(missing.length?"bad":"ok")+'">'+(missing.length?("incomplete — missing "+missing.join(", ")):"complete")+'</span>'+scoreSpan+'</h3>'+
         '<table class="mt"><thead><tr><th>Role</th><th>Name</th><th>Email</th><th>Joined</th></tr></thead><tbody>'+mem+'</tbody></table></div>';
     }).join("");
     var roleLine = ["conductor","critic","architect","scribe","facilitator"].map(function(rk){ return ROLE_LABELS[rk]+": <b>"+(roleCounts[rk]||0)+"</b>"; }).join(" &nbsp;·&nbsp; ");
@@ -269,6 +368,7 @@
       '.rt{margin:14px 0;break-inside:avoid}.rt h3{font-size:15px;margin:0 0 6px}'+
       '.rt h3 span{font-size:11px;font-weight:600;padding:2px 8px;border-radius:20px;margin-left:8px}'+
       '.ok{background:#D7F0E6;color:#1f8a63}.bad{background:#FBEBD3;color:#8a560f}'+
+      '.score{background:#122A47;color:#fff;font-family:monospace}'+
       '.mt{border-collapse:collapse;width:100%;font-size:13px}'+
       '.mt th{background:#122A47;color:#fff;text-align:left;padding:6px 9px;font-size:12px}'+
       '.mt td{border-bottom:1px solid #E1E8F1;padding:6px 9px}'+
@@ -294,14 +394,66 @@
     w.document.open(); w.document.write(reportHtml()); w.document.close();
   });
 
-  render([]);
+  // ---------- evaluate modal ----------
+  var adapterRef = null, evalKey = null;
+  var evalModal=$("#evalModal");
+  function emUpdateTotal(){
+    var t = clampNum($("#emI1").value,MAX_INJ)+clampNum($("#emI2").value,MAX_INJ)+clampNum($("#emI3").value,MAX_INJ)+clampNum($("#emSol").value,MAX_SOL);
+    $("#emTotal").textContent = t; return t;
+  }
+  ["emI1","emI2","emI3","emSol"].forEach(function(id){ $("#"+id).addEventListener("input", emUpdateTotal); });
+  function openEval(tk){
+    var sol=solutions[tk], sc=scores[tk];
+    var teamName = (sol&&sol.teamName) || (scores[tk]&&scores[tk].teamName) || tk;
+    evalKey = tk;
+    $("#emTeam").textContent = teamName;
+    $("#emMeta").textContent = sol ? ("Submitted "+fmtTime(sol.submittedAt)+(sol.submittedByName?(" · by "+sol.submittedByName):"")) : "No submission on record";
+    var solEl=$("#emSolution");
+    if(sol && sol.fields && sol.fields.length){
+      solEl.innerHTML = sol.fields.map(function(f){
+        var v=(f.value||"").trim();
+        return '<div class="em-field"><div class="k">'+esc(f.label)+'</div><div class="v'+(v?'':' empty')+'">'+(v?esc(v):"— left blank —")+'</div></div>';
+      }).join("");
+    } else {
+      solEl.innerHTML = '<div class="em-field"><div class="v empty">This team hasn\'t submitted a solution sheet. You can still score from their diagram / discussion.</div></div>';
+    }
+    $("#emI1").value = sc?sc.i1:""; $("#emI2").value = sc?sc.i2:""; $("#emI3").value = sc?sc.i3:"";
+    $("#emSol").value = sc?sc.solution:""; $("#emNotes").value = sc?(sc.notes||""):"";
+    emUpdateTotal();
+    evalModal.hidden=false;
+  }
+  function closeEval(){ evalModal.hidden=true; evalKey=null; }
+  $("#emClose").addEventListener("click", closeEval);
+  $("#emCancel").addEventListener("click", closeEval);
+  evalModal.addEventListener("click", function(e){ if(e.target===evalModal) closeEval(); });
+  document.addEventListener("keydown", function(e){ if(e.key==="Escape" && !evalModal.hidden) closeEval(); });
+  $("#emSave").addEventListener("click", function(){
+    if(!evalKey || !adapterRef) return;
+    var i1=clampNum($("#emI1").value,MAX_INJ), i2=clampNum($("#emI2").value,MAX_INJ), i3=clampNum($("#emI3").value,MAX_INJ), sv=clampNum($("#emSol").value,MAX_SOL);
+    var sol=solutions[evalKey];
+    var teamName=(sol&&sol.teamName) || (scores[evalKey]&&scores[evalKey].teamName) || evalKey;
+    var doc={ id:ROOM+"__"+evalKey, room:ROOM, teamName:teamName, i1:i1,i2:i2,i3:i3, solution:sv, total:i1+i2+i3+sv, notes:($("#emNotes").value||"").trim(), evaluatedAt:Date.now() };
+    try{ adapterRef.write("scores", doc); }catch(e){}
+    scores[evalKey]=doc; // optimistic
+    closeEval(); render();
+  });
+  // delegate Evaluate buttons
+  $("#teams").addEventListener("click", function(e){
+    var btn=e.target.closest ? e.target.closest("[data-eval]") : null;
+    if(btn) openEval(btn.getAttribute("data-eval"));
+  });
+
+  render();
   if(window.ZTDSRoster){
     window.ZTDSRoster.init(ROOM).then(function(adapter){
+      adapterRef = adapter;
       var live = adapter.mode==="firebase";
       $("#status").className = "status "+(live?"live":"local");
       $("#statusText").textContent = live ? "Live · Firebase" : "Single-device (local)";
       $("#localNotice").hidden = live;
-      adapter.subscribe(render);
+      adapter.watch("players", ROOM, function(d){ latest=d||[]; render(); });
+      adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
     });
   } else {
     $("#statusText").textContent = "Roster unavailable";

--- a/roster.js
+++ b/roster.js
@@ -1,44 +1,63 @@
 /* ============================================================================
-   Shared roster for the Zero Trust Agentic Design Sprint.
-   Used by both the participant page and proctor.html.
+   Shared store for the Zero Trust Agentic Design Sprint.
+   Used by the participant page, proctor.html, and leaderboard.html.
 
-   Exposes window.ZTDSRoster.init(room) -> Promise<adapter>, where adapter is:
-     { mode, join(player), subscribe(cb) -> unsubscribe }
+   window.ZTDSRoster.init(room) -> Promise<adapter>, where adapter is:
+     { mode, write(collection, doc), watch(collection, room, cb) -> unsubscribe }
+
+   `doc` must include an `id` and a `room` field. Collections used:
+     - "players"   : one doc per participant  {id, room, name, email, role, roleKey, teamName, joinedAt}
+     - "solutions" : one doc per team         {id, room, teamName, submittedByName, submittedAt, fields[]}
+     - "scores"    : one doc per team         {id, room, teamName, i1, i2, i3, solution, total, notes, evaluatedByName, evaluatedAt}
 
    If firebase-config.js is filled in, it uses Firestore (real cross-device
    sync). Otherwise it transparently falls back to a single-device localStorage
-   roster so the pages still work (useful for testing / one-device demos).
+   store so the pages still work (testing / one-device demos).
    ========================================================================== */
 (function () {
   "use strict";
   var SDK = "https://www.gstatic.com/firebasejs/10.12.2/";
 
-  function lsKey(room) { return "ztds.roster." + room; }
+  function lsKey(coll, room) { return "ztds." + coll + "." + room; }
 
-  function localAdapter(room) {
-    function readAll() { try { return JSON.parse(localStorage.getItem(lsKey(room)) || "[]"); } catch (e) { return []; } }
-    function writeAll(a) { try { localStorage.setItem(lsKey(room), JSON.stringify(a)); } catch (e) {} }
-    var listeners = [];
-    function emit() { var d = readAll(); listeners.forEach(function (fn) { fn(d); }); }
-    window.addEventListener("storage", function (e) { if (e.key === lsKey(room)) emit(); });
+  function localAdapter() {
+    function readAll(coll, room) { try { return JSON.parse(localStorage.getItem(lsKey(coll, room)) || "[]"); } catch (e) { return []; } }
+    function writeAll(coll, room, a) { try { localStorage.setItem(lsKey(coll, room), JSON.stringify(a)); } catch (e) {} }
+    var listeners = []; // { coll, room, cb }
+    function emit(coll, room) { var d = readAll(coll, room); listeners.forEach(function (l) { if (l.coll === coll && l.room === room) l.cb(d); }); }
+    window.addEventListener("storage", function (e) {
+      if (!e.key || e.key.indexOf("ztds.") !== 0) return;
+      var parts = e.key.split("."); // ztds.<coll>.<room...>
+      if (parts.length >= 3) { var coll = parts[1]; var room = parts.slice(2).join("."); emit(coll, room); }
+    });
     return {
       mode: "local",
-      join: function (p) { var a = readAll(); var i = a.findIndex(function (x) { return x.id === p.id; }); if (i >= 0) a[i] = Object.assign(a[i], p); else a.push(p); writeAll(a); emit(); return Promise.resolve(); },
-      subscribe: function (cb) { cb(readAll()); listeners.push(cb); var iv = setInterval(function () { cb(readAll()); }, 2000); return function () { clearInterval(iv); }; }
+      write: function (coll, doc) {
+        var room = doc.room; var a = readAll(coll, room);
+        var i = a.findIndex(function (x) { return x.id === doc.id; });
+        if (i >= 0) a[i] = Object.assign(a[i], doc); else a.push(doc);
+        writeAll(coll, room, a); emit(coll, room); return Promise.resolve();
+      },
+      watch: function (coll, room, cb) {
+        cb(readAll(coll, room));
+        var l = { coll: coll, room: room, cb: cb }; listeners.push(l);
+        var iv = setInterval(function () { cb(readAll(coll, room)); }, 2000);
+        return function () { clearInterval(iv); var idx = listeners.indexOf(l); if (idx >= 0) listeners.splice(idx, 1); };
+      }
     };
   }
 
-  function firebaseAdapter(room, cfg) {
+  function firebaseAdapter(cfg) {
     return import(SDK + "firebase-app.js").then(function (appMod) {
       return import(SDK + "firebase-firestore.js").then(function (fs) {
         var app = appMod.initializeApp(cfg);
         var db = fs.getFirestore(app);
         return {
           mode: "firebase",
-          join: function (p) { return fs.setDoc(fs.doc(db, "players", p.id), p, { merge: true }); },
-          subscribe: function (cb) {
-            var q = fs.query(fs.collection(db, "players"), fs.where("room", "==", room));
-            return fs.onSnapshot(q, function (snap) { var d = []; snap.forEach(function (doc) { d.push(doc.data()); }); cb(d); });
+          write: function (coll, doc) { return fs.setDoc(fs.doc(db, coll, doc.id), doc, { merge: true }); },
+          watch: function (coll, room, cb) {
+            var q = fs.query(fs.collection(db, coll), fs.where("room", "==", room));
+            return fs.onSnapshot(q, function (snap) { var d = []; snap.forEach(function (docSnap) { d.push(docSnap.data()); }); cb(d); });
           }
         };
       });
@@ -50,12 +69,12 @@
     var cfg = window.FIREBASE_CONFIG;
     var configured = cfg && cfg.apiKey && cfg.apiKey.indexOf("PASTE") !== 0;
     if (configured) {
-      return firebaseAdapter(room, cfg).catch(function (e) {
+      return firebaseAdapter(cfg).catch(function (e) {
         console.warn("[roster] Firebase unavailable, using local fallback:", e && e.message);
-        return localAdapter(room);
+        return localAdapter();
       });
     }
-    return Promise.resolve(localAdapter(room));
+    return Promise.resolve(localAdapter());
   }
 
   window.ZTDSRoster = { init: init };

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -516,6 +516,9 @@
   .sheet-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:12px;padding-bottom:12px;border-bottom:1px dashed var(--line-soft)}
   .sheet-tools .st-note{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--ink-faint);margin-right:auto}
   .sheet-tools .st-note b{color:var(--green)}
+  .st-btn.go{background:var(--green);border-color:var(--green);color:#fff}
+  .st-btn.go:hover{background:#2cb583;border-color:#2cb583}
+  .st-status{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--green);white-space:nowrap}
   .st-btn{
     font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;letter-spacing:.04em;
     color:var(--ink);background:#F4F7FB;border:1px solid var(--line);border-radius:8px;
@@ -2029,7 +2032,9 @@
       '<span class="st-note">Type directly into the sheet — <b>saved in this browser</b> automatically.</span>'+
       '<button class="st-btn" data-copy><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 012-2h8"/></svg>Copy</button>'+
       '<button class="st-btn" data-print><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 9V3h12v6"/><rect x="4" y="9" width="16" height="8" rx="2"/><path d="M8 17h8v4H8z"/></svg>Print</button>'+
-      '<button class="st-btn" data-clear><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 7h16M9 7V4h6v3M7 7l1 13h8l1-13"/></svg>Clear</button>';
+      '<button class="st-btn" data-clear><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 7h16M9 7V4h6v3M7 7l1 13h8l1-13"/></svg>Clear</button>'+
+      '<span class="st-status" data-substatus></span>'+
+      '<button class="st-btn go" data-submit><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 12l5 5L20 6"/></svg>Submit for scoring</button>';
     body.insertBefore(tools, body.firstChild);
 
     var inputs=[];
@@ -2065,6 +2070,31 @@
       var t=document.createElement("textarea"); t.value=text; t.style.position="fixed"; t.style.opacity="0";
       document.body.appendChild(t); t.select(); try{ document.execCommand("copy"); }catch(e){} document.body.removeChild(t);
     }
+
+    // --- submit for scoring (sends the solution to the proctor via the shared store) ---
+    var statusEl = tools.querySelector("[data-substatus]");
+    var subBtn = tools.querySelector("[data-submit]");
+    function teamKey(t){ return (t||"").trim().toLowerCase(); }
+    function refreshSubmitStatus(){
+      if(!persona || !persona.team){ statusEl.textContent=""; subBtn.lastChild.textContent="Submit for scoring"; return; }
+      var t=null; try{ t=localStorage.getItem("ztds.submittedAt."+teamKey(persona.team)); }catch(e){}
+      if(t){ statusEl.textContent="Submitted "+new Date(+t).toLocaleTimeString(); subBtn.lastChild.textContent="Re-submit for scoring"; }
+      else { statusEl.textContent=""; subBtn.lastChild.textContent="Submit for scoring"; }
+    }
+    subBtn.addEventListener("click", function(){
+      if(!persona || persona.role==="facilitator" || !persona.team){
+        toast("Take your seat first","Click “Take your seat” (top bar) and enter your team name before submitting for scoring.","fire"); return;
+      }
+      if(!roster){ toast("Not connected yet","The scoring sync isn't ready — wait a moment and try again.","fire"); return; }
+      var tk=teamKey(persona.team), when=Date.now();
+      var doc={ id:ROOM+"__"+tk, room:ROOM, teamName:persona.team, submittedByName:persona.name||"", submittedAt:when,
+                fields: inputs.map(function(x){ return { label:x.label, value:x.ta.value.trim() }; }) };
+      try{ roster.write("solutions", doc); }catch(e){}
+      try{ localStorage.setItem("ztds.submittedAt."+tk, String(when)); }catch(e){}
+      refreshSubmitStatus();
+      toast("Submitted for scoring","Your team’s solution was sent to the proctor. You can edit and re-submit until it’s scored.","phase");
+    });
+    setTimeout(refreshSubmitStatus, 0);
   }
 
   // ---------- persona "take your seat" login ----------
@@ -2090,7 +2120,7 @@
   if(window.ZTDSRoster){
     window.ZTDSRoster.init(ROOM).then(function(a){
       roster=a;
-      if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.team){ try{ roster.join(rosterRecord(persona)); }catch(e){} }
+      if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.team){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
     });
   }
   var pl=$("#pmProctorLink"); if(pl) pl.href="proctor.html"+(ROOM!=="default"?("?room="+encodeURIComponent(ROOM)):"");
@@ -2176,7 +2206,7 @@
     persona={ role:key, name:name, email:email, team:team, joinedAt:Date.now() };
     try{ localStorage.setItem("ztds.persona", JSON.stringify(persona)); }catch(e){}
     applyPersona(); closePersona();
-    if(roster && key!=="facilitator"){ try{ roster.join(rosterRecord(persona)); }catch(e){} }
+    if(roster && key!=="facilitator"){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
     toast("Seat taken", (name?esc(name)+", you":"You")+" are <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+".", "phase");
   }
   $("#btnPersona").addEventListener("click", openPersona);


### PR DESCRIPTION
## Summary

Adds team scoring, proctor evaluation of submitted designs, and a live leaderboard.

## What's new

- **Submit for scoring** (participant page): after taking a seat with a team, a team sends its solution sheet to a shared `solutions` store; shows submitted status and supports re-submit.
- **Proctor evaluation** (`proctor.html`): each submitted team gets an **Evaluate** button that opens the full submitted solution alongside a scoring form — **3 injections (10 each) + final solution vs. the 8 reference controls (70) = 100**, with a live total and notes. Team cards show score + live rank; the participant report now includes scores; the summary shows submitted/scored counts.
- **Leaderboard** (`leaderboard.html`, new): live team ranking by total, with medals and per-team breakdown; room-scoped; meant for the shared screen.

## Under the hood

- `roster.js` generalized to a small `write(collection, doc)` / `watch(collection, room, cb)` store over Firestore (or the localStorage fallback), backing `players`, `solutions`, and `scores`.
- **Firestore rules extended** to cover `solutions` and `scores` (see `firebase-config.js` / `SETUP.md`). ⚠️ The previously published rules were players-only — they must be **re-published** or submissions/scores will be rejected in live mode.
- Docs updated (README, SETUP, FACILITATOR).

## Scope

Evaluation is **manual by the proctor** (as chosen). AI-agent evaluation is not included in this version.

## Testing

End-to-end in headless Chromium: submit → proctor evaluate (live total 84) → team card shows 84/100 rank #1 → leaderboard ranks it with a gold medal; multi-team leaderboard and eval modal verified visually; all three pages load with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_