### PR TITLE
Let the proctor start the event for all participants

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -29,8 +29,8 @@ the in-session phase/time cues live on the participant page itself.)
 
 ## Running the hour (60 min)
 
-- [ ] *(Optional)* Press **Focus** in the control bar to hide reference sections (rubric, journey, worked example, etc.) — this cuts the on-page reading ~in half so teams stay on task. Toggle **Show all** anytime.
-- [ ] On the participant page's **control bar**, press **Start** — the 60-minute clock drives everything.
+- [ ] *(Optional)* Ask teams to press **Focus** in their control bar to hide reference sections (rubric, journey, worked example, etc.) — cuts on-page reading ~in half. Toggle **Show all** anytime.
+- [ ] On **`proctor.html`**, press **Start event** — this starts the single 60-minute clock **for all participants at once** (their local Start/Pause is locked while the event runs). Use **Pause/Resume** and **Reset** there to control the whole room. *(If you're not using the proctor page, each participant can still press Start on their own control bar.)*
 - [ ] The board and phase cards auto-highlight the current phase; **injections auto-reveal** at 24/38/50 min with a chime + toast.
 - [ ] The in-game **Conductor** on each team keeps their table on pace; you float between tables.
 - [ ] `Jump` advances a phase if needed; `Reset` restarts the clock (re-seals injections). Chimes toggle with the speaker button.

--- a/SETUP.md
+++ b/SETUP.md
@@ -69,15 +69,21 @@ service cloud.firestore {
         request.resource.data.total is number;
       allow delete: if false;
     }
+    match /control/{id} {
+      allow read: if true;
+      allow create, update: if request.resource.data.room is string;
+      allow delete: if false;
+    }
   }
 }
 ```
 
-Covers three collections: `players` (roster), `solutions` (submitted design sheets), and
-`scores` (proctor evaluations). Allows registering/submitting/scoring and reading; blocks
-client-side deletes. **Do not leave Firestore in open "test mode"** — that exposes participant
-emails. **If you published an earlier players-only version of these rules, re-publish this one**
-or solution submissions and scores will be rejected.
+Covers four collections: `players` (roster), `solutions` (submitted design sheets), `scores`
+(proctor evaluations), and `control` (the proctor's start/pause/reset of the shared clock).
+Allows registering/submitting/scoring/controlling and reading; blocks client-side deletes.
+**Do not leave Firestore in open "test mode"** — that exposes participant emails. **Whenever you
+add features you must re-publish this full block** — if an older version is live, submissions,
+scores, or the shared "Start event" clock will be rejected.
 
 ### 2d. (Optional) Restrict the API key — defense-in-depth  ⬜
 Google Cloud Console → **APIs & Services → Credentials** → project `design-clinic-58ad0` →

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -44,6 +44,11 @@
                 request.resource.data.total is number;
               allow delete: if false;
             }
+            match /control/{id} {
+              allow read: if true;
+              allow create, update: if request.resource.data.room is string;
+              allow delete: if false;
+            }
           }
         }
 

--- a/proctor.html
+++ b/proctor.html
@@ -50,6 +50,24 @@
   .notice{margin:12px 0 0;padding:11px 14px;border-radius:11px;font-size:13px;border:1px solid #F0CE97;background:#FBEBD3;color:#8a560f}
   .notice b{color:#6e440a}
 
+  /* session control (start the event for everyone) */
+  .control{display:flex;align-items:center;gap:16px;margin:14px 0 0;padding:14px 18px;background:linear-gradient(180deg,#0c1d34,#0a1830);border:1px solid rgba(255,255,255,.08);border-left:4px solid var(--cyan);border-radius:14px;color:#EAF1F8;box-shadow:var(--shadow);flex-wrap:wrap}
+  .ctl-clock{display:flex;align-items:baseline;gap:7px;font-family:"IBM Plex Mono",monospace}
+  .ctl-time{font-size:26px;font-weight:600;color:#fff;font-variant-numeric:tabular-nums}
+  .ctl-total{font-size:12px;color:#7E93AE}
+  .ctl-phase{display:flex;flex-direction:column;line-height:1.2;min-width:0;padding-left:14px;border-left:1px solid rgba(255,255,255,.14)}
+  .ctl-pname{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:15px;color:var(--pc,#7FE2EF)}
+  .ctl-status{font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:#8FA8C4;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:46vw}
+  .ctl-bar{flex:1;min-width:80px;max-width:340px;height:7px;border-radius:4px;background:rgba(255,255,255,.12);overflow:hidden}
+  .ctl-bar i{display:block;height:100%;width:0;background:var(--pc,var(--cyan));transition:width .3s linear,background .3s}
+  .ctl-btns{display:flex;gap:8px;margin-left:auto}
+  .control .btn{background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.18);color:#EAF1F8}
+  .control .btn:hover{background:rgba(255,255,255,.16)}
+  .control .btn.primary{background:var(--green);border-color:var(--green);color:#fff}
+  .control .btn.primary:hover{background:#2cb583}
+  .control .btn.warn{background:var(--amber);border-color:var(--amber);color:#fff}
+  @media (max-width:700px){ .control .ctl-bar{order:5;flex-basis:100%;max-width:none} .ctl-status{max-width:70vw} }
+
   .bar .filter{display:inline-flex;align-items:center;gap:6px;font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--ink-soft)}
   .bar .filter input{border:1px solid var(--line);border-radius:8px;padding:6px 9px;font-family:"IBM Plex Sans",sans-serif;font-size:13px;width:190px;outline:none}
   .bar .filter input:focus{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.12)}
@@ -155,6 +173,17 @@
   <div class="notice" id="localNotice" hidden>
     <b>Single-device mode.</b> Firebase isn't configured, so this roster only shows people who joined <b>on this device/browser</b>. To see every participant's device live, fill in <code>firebase-config.js</code> (setup steps are in that file).
   </div>
+
+  <div class="control" id="control">
+    <div class="ctl-clock"><span class="ctl-time" id="ctlTime">00:00</span><span class="ctl-total">/ 60:00</span></div>
+    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event not started</span><span class="ctl-status" id="ctlStatus">Press “Start event” to run the 60 minutes for everyone</span></div>
+    <div class="ctl-bar" aria-hidden="true"><i id="ctlFill"></i></div>
+    <div class="ctl-btns">
+      <button class="btn primary" id="ctlStart"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 4l14 8-14 8z"/></svg><span id="ctlStartLabel">Start event</span></button>
+      <button class="btn" id="ctlReset" title="Reset the event clock for everyone"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4v6h6"/><path d="M4 10a8 8 0 113 8"/></svg>Reset</button>
+    </div>
+  </div>
+
   <div class="summary" id="summary" hidden></div>
   <div class="showing" id="showing" hidden></div>
 
@@ -443,6 +472,39 @@
     if(btn) openEval(btn.getAttribute("data-eval"));
   });
 
+  // ---------- session control: start / pause / reset the event for everyone ----------
+  var PHASES=[{no:"PHASE 0",name:"Brief-In",start:0,end:8,color:"#E2891F"},{no:"PHASE 1",name:"Expose",start:8,end:20,color:"#DB4A4A"},{no:"PHASE 2",name:"Decide",start:20,end:33,color:"#0FA9BE"},{no:"PHASE 3",name:"Design",start:33,end:48,color:"#2a6fb0"},{no:"PHASE 4",name:"Document",start:48,end:56,color:"#27A276"},{no:"PHASE 5",name:"Submit",start:56,end:60,color:"#122A47"}];
+  var TOTAL=3600, ctl=null, controlEl=$("#control");
+  function ctlElapsed(){ if(!ctl||ctl.status==="idle") return 0; if(ctl.status==="running") return Math.min(TOTAL,(ctl.baseElapsedSec||0)+(Date.now()-(ctl.startedAtMs||Date.now()))/1000); return Math.min(TOTAL, ctl.baseElapsedSec||0); }
+  function fmtClock(s){ s=Math.max(0,Math.round(s)); var m=Math.floor(s/60),ss=s%60; return (m<10?"0":"")+m+":"+(ss<10?"0":"")+ss; }
+  function phaseAt(e){ if(e>=TOTAL) return null; for(var i=0;i<PHASES.length;i++){ if(e<PHASES[i].end*60) return PHASES[i]; } return PHASES[PHASES.length-1]; }
+  function renderControl(){
+    var e=ctlElapsed(), ph=phaseAt(e);
+    var status = (!ctl||ctl.status==="idle") ? "idle" : ctl.status;
+    $("#ctlTime").textContent=fmtClock(e);
+    $("#ctlFill").style.width=((e/TOTAL)*100)+"%";
+    controlEl.style.setProperty("--pc", e>=TOTAL?"#122A47":(ph?ph.color:"#0FA9BE"));
+    var lbl=$("#ctlStartLabel"), sb=$("#ctlStart");
+    if(status==="running"){ lbl.textContent="Pause"; sb.className="btn warn"; }
+    else if(status==="paused"){ lbl.textContent="Resume"; sb.className="btn primary"; }
+    else { lbl.textContent="Start event"; sb.className="btn primary"; }
+    if(e>=TOTAL){ $("#ctlPhase").textContent="Time — hands off"; $("#ctlStatus").textContent="60 minutes elapsed"; }
+    else if(status==="idle"){ $("#ctlPhase").textContent="Event not started"; $("#ctlStatus").textContent="Press “Start event” to run the 60 minutes for everyone"; }
+    else { $("#ctlPhase").textContent=ph.no+" · "+ph.name; $("#ctlStatus").textContent=(status==="paused"?"Paused · ":"Running · ")+fmtClock(ph.end*60-e)+" left in phase"; }
+  }
+  function writeCtl(doc){ if(!adapterRef){ alert("Not connected yet — try again in a moment."); return; } doc.id=ROOM; doc.room=ROOM; doc.updatedAt=Date.now(); ctl=doc; try{ adapterRef.write("control", doc); }catch(e){} renderControl(); }
+  $("#ctlStart").addEventListener("click", function(){
+    var status=(!ctl||ctl.status==="idle")?"idle":ctl.status, now=Date.now();
+    if(status==="idle"){ if(!confirm("Start the 60-minute clock now for ALL participants?")) return; writeCtl({status:"running",runId:now,startedAtMs:now,baseElapsedSec:0}); }
+    else if(status==="running"){ var base=(ctl.baseElapsedSec||0)+(now-(ctl.startedAtMs||now))/1000; writeCtl({status:"paused",runId:ctl.runId,startedAtMs:ctl.startedAtMs,baseElapsedSec:base}); }
+    else { writeCtl({status:"running",runId:ctl.runId,startedAtMs:now,baseElapsedSec:ctl.baseElapsedSec||0}); }
+  });
+  $("#ctlReset").addEventListener("click", function(){
+    if(!confirm("Reset the event clock to 00:00 for everyone? This re-seals the injections on all participant pages.")) return;
+    writeCtl({status:"idle",runId:0,startedAtMs:0,baseElapsedSec:0});
+  });
+  setInterval(renderControl,250); renderControl();
+
   render();
   if(window.ZTDSRoster){
     window.ZTDSRoster.init(ROOM).then(function(adapter){
@@ -454,6 +516,7 @@
       adapter.watch("players", ROOM, function(d){ latest=d||[]; render(); });
       adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[tkey(s.teamName)]=s; }); render(); });
       adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("control", ROOM, function(d){ ctl=(d&&d.length)?d[0]:null; renderControl(); });
     });
   } else {
     $("#statusText").textContent = "Roster unavailable";

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -440,6 +440,7 @@
   .fb-btn svg{width:14px;height:14px;stroke-width:2.2}
   .fb-btn.icon{padding:8px 10px}
   .fb-btn[aria-pressed="false"]{opacity:.55}
+  .fb-btn:disabled{opacity:.5;cursor:not-allowed}
   @media (max-width:880px){
     .facilbar{flex-wrap:wrap;min-height:0;padding:8px 12px;gap:9px}
     body.has-bar{padding-top:104px}
@@ -1815,6 +1816,47 @@
     CUES.forEach(function(c,i){ if(elapsed>=c.sec) fired["cue"+i]=true; });
     INJ.forEach(function(j,i){ if(elapsed>=j.sec) fired["inj"+i]=true; });
   }
+  function primeFiredUpTo(e){ fired={}; CUES.forEach(function(c,i){ if(e>=c.sec) fired["cue"+i]=true; }); INJ.forEach(function(j,i){ if(e>=j.sec) fired["inj"+i]=true; }); }
+
+  // ---------- proctor-controlled clock (a proctor "starts the event for all") ----------
+  var proctorControlled=false, ctrl=null, primedForRun=null, ctrlTicker=null;
+  function elapsedFromCtrl(){
+    if(!ctrl || ctrl.status==="idle") return 0;
+    if(ctrl.status==="running") return Math.min(TOTAL, (ctrl.baseElapsedSec||0) + (Date.now()-(ctrl.startedAtMs||Date.now()))/1000);
+    return Math.min(TOTAL, ctrl.baseElapsedSec||0); // paused
+  }
+  function updateControlUI(){
+    var b=$("#btnStart"), lbl=$("#btnStartLabel"), sk=$("#btnSkip"), rs=$("#btnReset");
+    if(proctorControlled){
+      b.disabled=true; sk.disabled=true; rs.disabled=true;
+      b.title=sk.title=rs.title="The proctor controls the timer for everyone";
+      lbl.textContent = ctrl && ctrl.status==="running" ? "Live" : (ctrl && ctrl.status==="paused" ? "Paused" : "Waiting");
+    } else {
+      b.disabled=false; sk.disabled=false; rs.disabled=false;
+    }
+  }
+  function controlledTick(){
+    elapsed=elapsedFromCtrl(); running=(ctrl && ctrl.status==="running");
+    render(); checkEvents(); updateControlUI();
+  }
+  function applyControl(doc){
+    if(!doc) return; // no central session -> stay in local mode
+    proctorControlled=true; ctrl=doc;
+    if(ticker){ clearInterval(ticker); ticker=null; } // local timer yields to the proctor
+    if(doc.status==="idle"){
+      if(primedForRun!=="idle"){ fired={}; INJ.forEach(function(j){ j.manual=false; }); toastWrap.innerHTML=""; primedForRun="idle"; }
+      elapsed=0;
+    } else if(primedForRun !== doc.runId){ // a new run started (or we just joined mid-run)
+      elapsed=elapsedFromCtrl();
+      primeFiredUpTo(elapsed);                 // don't replay past cues; future crossings still fire
+      INJ.forEach(function(j){ j.manual=false; });
+      if(elapsed<2){ toastWrap.innerHTML=""; toast("Session started","The proctor started the 60 minutes — Phase 0 · Brief-In begins now.","phase","00:00"); }
+      primedForRun=doc.runId;
+    }
+    elapsed=elapsedFromCtrl(); running=(doc.status==="running");
+    if(!ctrlTicker) ctrlTicker=setInterval(controlledTick, 250);
+    updateControlUI(); render(); checkEvents();
+  }
 
   // ---------- audio chimes ----------
   function initAudio(){
@@ -1907,8 +1949,8 @@
       $("#barNext").textContent = fmt(leftInPhase)+" left in phase · "+nextTxt;
     }
 
-    // start button label
-    $("#btnStartLabel").textContent = running ? "Pause" : (elapsed>0 && elapsed<TOTAL ? "Resume" : "Start");
+    // start button label (skipped while proctor-controlled — updateControlUI owns it)
+    if(!proctorControlled) $("#btnStartLabel").textContent = running ? "Pause" : (elapsed>0 && elapsed<TOTAL ? "Resume" : "Start");
 
     // board stops
     STOPS.forEach(function(s,i){
@@ -1968,11 +2010,13 @@
 
   // ---------- controls ----------
   $("#btnStart").addEventListener("click", function(){
+    if(proctorControlled) return;
     initAudio();
     if(running){ stop(); }
     else { if(elapsed===0) toast("Session started","60 minutes on the clock — Phase 0 · Brief-In begins now.","phase","00:00"); startTimer(); }
   });
   $("#btnSkip").addEventListener("click", function(){
+    if(proctorControlled) return;
     var idx=currentPhaseIndex();
     if(idx>=PHASES.length) return;
     var nextStart = (idx+1<=PHASES.length-1) ? PHASES[idx+1].start*60 : TOTAL;
@@ -1981,6 +2025,7 @@
     render(); checkEvents(); save();
   });
   $("#btnReset").addEventListener("click", function(){
+    if(proctorControlled) return;
     if(!confirm("Reset the session clock to 00:00 and re-seal all injections?\n\n(Your checklists and solution sheet are kept.)")) return;
     stop(); elapsed=0; fired={};
     INJ.forEach(function(j){ j.manual=false; });
@@ -2121,6 +2166,7 @@
     window.ZTDSRoster.init(ROOM).then(function(a){
       roster=a;
       if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.team){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
+      try{ roster.watch("control", ROOM, function(d){ var doc=(d&&d[0])||null; applyControl(doc); }); }catch(e){}
     });
   }
   var pl=$("#pmProctorLink"); if(pl) pl.href="proctor.html"+(ROOM!=="default"?("?room="+encodeURIComponent(ROOM)):"");


### PR DESCRIPTION
## Summary

Adds a proctor-controlled shared clock so one **Start event** runs the 60 minutes for the whole room at once.

## What's new

- **Proctor Session Control panel** (`proctor.html`): a live clock + phase readout with **Start event / Pause / Resume / Reset**. Each action writes a shared `control` record (`status`, `runId`, `startedAtMs`, `baseElapsedSec`).
- **Participants follow it** (`zero-trust-design-sprint.html`): each participant page watches the `control` record and drives its 60-minute clock from it in real time — everyone starts, pauses, and resets together. While a proctor session is active, the participant's local Start/Pause/Reset is **locked** and the button shows **Live / Paused / Waiting**.
- **Backward compatible:** with no proctor session, participants' local timer controls work exactly as before.
- Injections still auto-reveal off the shared clock; joining mid-run primes past events so there's no toast burst.

## Firebase

- Rules extended with a **`control`** collection (see `firebase-config.js` / `SETUP.md`). ⚠️ Must be **re-published** or "Start event" won't propagate in live mode.

## Testing

End-to-end in headless Chromium: proctor Start → participant shows Live and the clock advances (00:02) with the correct phase active and local button disabled; Pause freezes the participant clock; Resume continues; Reset returns everyone to 00:00 (Waiting). All three pages load with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_