### PR TITLE
Proctor opens the event; each team runs its own 60-minute clock

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -22,19 +22,18 @@ the in-session phase/time cues live on the participant page itself.)
 
 ## As people arrive (5 min)
 
-- [ ] Each person opens the participant link and clicks **Take your seat**: name, email, **team name**, role.
-- [ ] Watch them appear on your **proctor** screen, grouped by team.
-- [ ] Use the proctor **summary** to spot gaps: each team should show **4/4 roles** (no amber "Missing:" flags).
-- [ ] Nudge under/over-filled teams to rebalance before the clock starts.
+- [ ] Participants who open the link **before you open the event** see a **"Waiting for the proctor…"** screen — that's expected.
+- [ ] When ready, on **`proctor.html`** press **Open event**. Everyone's waiting screen clears and they're prompted to take their seat.
+- [ ] Each person clicks **Take your seat**: name, email, **team name**, role. **The team's own 60-minute clock starts the moment the first teammate registers** — so a team begins when *they* are ready; teammates who join after start on the same running clock.
+- [ ] Watch teams appear on your **proctor** screen, grouped by team, each showing a live **⏱ time-left** clock. Use the **summary** to spot gaps (each team should show **4/4 roles**).
 
-## Running the hour (60 min)
+## Running the hour (per-team 60 min)
 
-- [ ] *(Optional)* Ask teams to press **Focus** in their control bar to hide reference sections (rubric, journey, worked example, etc.) — cuts on-page reading ~in half. Toggle **Show all** anytime.
-- [ ] On **`proctor.html`**, press **Start event** — this starts the single 60-minute clock **for all participants at once** (their local Start/Pause is locked while the event runs). Use **Pause/Resume** and **Reset** there to control the whole room. *(If you're not using the proctor page, each participant can still press Start on their own control bar.)*
-- [ ] The board and phase cards auto-highlight the current phase; **injections auto-reveal** at 24/38/50 min with a chime + toast.
+- [ ] *(Optional)* Ask teams to press **Focus** in their control bar to hide reference sections — cuts on-page reading ~in half. Toggle **Show all** anytime.
+- [ ] Each team's board, phases, and **injection reveals (24/38/50 min)** run off **their own** clock — teams that started later reach each phase later. The proctor roster shows every team's remaining time.
 - [ ] The in-game **Conductor** on each team keeps their table on pace; you float between tables.
-- [ ] `Jump` advances a phase if needed; `Reset` restarts the clock (re-seals injections). Chimes toggle with the speaker button.
-- [ ] Keep the **proctor** tab open on the side to see the live roster throughout.
+- [ ] Participants' local Start/Pause is **locked** while the event is open — the clock is automatic per team.
+- [ ] Press **Close event** when you want to stop new teams from starting (teams already running keep their clocks). Keep the **proctor** tab open to watch the roster and clocks throughout.
 
 ## After the clock (10 min)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -114,8 +114,12 @@ Troubleshooting:
 
 - **Multiple rooms/cohorts:** add `?room=CODE` to *both* page URLs to scope a roster to one
   session, e.g. `…/proctor.html?room=june-cohort` and `…/zero-trust-design-sprint.html?room=june-cohort`.
-- **Facilitator timer:** the control bar drives the 60-minute clock, phase highlighting, and
-  timed injection reveals; the proctor page is a separate live roster.
+- **Opening the event:** on `proctor.html`, press **Open event**. Until then, participants see a
+  "Waiting for the proctor…" screen. Once open, each team's own 60-minute clock starts when that
+  team takes their seats — so teams can begin at their own pace, and each team's phases and
+  injection reveals run off their own clock. The proctor roster shows every team's time remaining.
+  Press **Close event** to stop new teams from starting. *(If no proctor opens an event, a
+  participant page falls back to a local self-run timer.)*
 - **Reports:** on `proctor.html`, use **Export CSV** for raw data or **Report** for a printable
   (PDF-ready) participant summary with per-team completeness. Scales to ~300 participants.
 - **Scoring & leaderboard:** teams click **Submit for scoring** on the participant page (after

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -61,6 +61,7 @@
 window.FIREBASE_CONFIG = {
   apiKey: "AIzaSyBttVNwx0VOhTiMgMF6EAxn-f9X6au2CaA",
   authDomain: "design-clinic-58ad0.firebaseapp.com",
+  databaseURL: "https://design-clinic-58ad0-default-rtdb.firebaseio.com",
   projectId: "design-clinic-58ad0",
   storageBucket: "design-clinic-58ad0.firebasestorage.app",
   messagingSenderId: "278404586451",

--- a/proctor.html
+++ b/proctor.html
@@ -66,7 +66,16 @@
   .control .btn.primary{background:var(--green);border-color:var(--green);color:#fff}
   .control .btn.primary:hover{background:#2cb583}
   .control .btn.warn{background:var(--amber);border-color:var(--amber);color:#fff}
-  @media (max-width:700px){ .control .ctl-bar{order:5;flex-basis:100%;max-width:none} .ctl-status{max-width:70vw} }
+  .control .ctl-time{color:var(--amber)}
+  .control.open{border-left-color:var(--green)}
+  .control.open .ctl-time{color:#7FE2EF}
+  /* per-team clocks on roster cards */
+  .clock-row{padding:8px 16px;border-top:1px solid var(--line-soft);background:#FAFCFF}
+  .tclock{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:600;color:var(--cyan-deep)}
+  .tclock.idle{color:var(--ink-faint);font-weight:400}
+  .tclock.low{color:var(--amber)}
+  .tclock.up{color:var(--red)}
+  @media (max-width:700px){ .ctl-status{max-width:70vw} }
 
   .bar .filter{display:inline-flex;align-items:center;gap:6px;font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--ink-soft)}
   .bar .filter input{border:1px solid var(--line);border-radius:8px;padding:6px 9px;font-family:"IBM Plex Sans",sans-serif;font-size:13px;width:190px;outline:none}
@@ -175,12 +184,10 @@
   </div>
 
   <div class="control" id="control">
-    <div class="ctl-clock"><span class="ctl-time" id="ctlTime">00:00</span><span class="ctl-total">/ 60:00</span></div>
-    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event not started</span><span class="ctl-status" id="ctlStatus">Press “Start event” to run the 60 minutes for everyone</span></div>
-    <div class="ctl-bar" aria-hidden="true"><i id="ctlFill"></i></div>
+    <div class="ctl-clock"><span class="ctl-time" id="ctlTime">CLOSED</span></div>
+    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event not started</span><span class="ctl-status" id="ctlStatus">Press “Open event” — each team then starts their own 60 minutes when they take their seats</span></div>
     <div class="ctl-btns">
-      <button class="btn primary" id="ctlStart"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 4l14 8-14 8z"/></svg><span id="ctlStartLabel">Start event</span></button>
-      <button class="btn" id="ctlReset" title="Reset the event clock for everyone"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 4v6h6"/><path d="M4 10a8 8 0 113 8"/></svg>Reset</button>
+      <button class="btn primary" id="ctlStart"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12l5 5L20 7"/></svg><span id="ctlStartLabel">Open event</span></button>
     </div>
   </div>
 
@@ -338,8 +345,10 @@
       } else {
         footer = '<div class="score-row muted">No solution submitted yet</div>';
       }
-      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+rows+missHtml+footer+'</div>';
+      var clockLine = '<div class="clock-row"><span class="tclock idle" data-teamclock="'+esc(tk)+'">clock not started</span></div>';
+      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+clockLine+rows+missHtml+footer+'</div>';
     }).join("");
+    renderControl(); // refresh per-team clock spans right after rebuild
   }
 
   function toCsv(){
@@ -472,36 +481,38 @@
     if(btn) openEval(btn.getAttribute("data-eval"));
   });
 
-  // ---------- session control: start / pause / reset the event for everyone ----------
-  var PHASES=[{no:"PHASE 0",name:"Brief-In",start:0,end:8,color:"#E2891F"},{no:"PHASE 1",name:"Expose",start:8,end:20,color:"#DB4A4A"},{no:"PHASE 2",name:"Decide",start:20,end:33,color:"#0FA9BE"},{no:"PHASE 3",name:"Design",start:33,end:48,color:"#2a6fb0"},{no:"PHASE 4",name:"Document",start:48,end:56,color:"#27A276"},{no:"PHASE 5",name:"Submit",start:56,end:60,color:"#122A47"}];
-  var TOTAL=3600, ctl=null, controlEl=$("#control");
-  function ctlElapsed(){ if(!ctl||ctl.status==="idle") return 0; if(ctl.status==="running") return Math.min(TOTAL,(ctl.baseElapsedSec||0)+(Date.now()-(ctl.startedAtMs||Date.now()))/1000); return Math.min(TOTAL, ctl.baseElapsedSec||0); }
+  // ---------- event control: proctor opens the event; each team runs its own clock ----------
+  var TOTAL=3600, eventDoc=null, teamClocks={}, controlEl=$("#control"), armedOnce=false;
   function fmtClock(s){ s=Math.max(0,Math.round(s)); var m=Math.floor(s/60),ss=s%60; return (m<10?"0":"")+m+":"+(ss<10?"0":"")+ss; }
-  function phaseAt(e){ if(e>=TOTAL) return null; for(var i=0;i<PHASES.length;i++){ if(e<PHASES[i].end*60) return PHASES[i]; } return PHASES[PHASES.length-1]; }
+  function isOpen(){ return !!(eventDoc && eventDoc.status==="open"); }
+  function teamRemaining(tk){ var t=teamClocks[tk]; if(!t||!t.startedAt) return null; return Math.max(0, TOTAL-(Date.now()-t.startedAt)/1000); }
   function renderControl(){
-    var e=ctlElapsed(), ph=phaseAt(e);
-    var status = (!ctl||ctl.status==="idle") ? "idle" : ctl.status;
-    $("#ctlTime").textContent=fmtClock(e);
-    $("#ctlFill").style.width=((e/TOTAL)*100)+"%";
-    controlEl.style.setProperty("--pc", e>=TOTAL?"#122A47":(ph?ph.color:"#0FA9BE"));
-    var lbl=$("#ctlStartLabel"), sb=$("#ctlStart");
-    if(status==="running"){ lbl.textContent="Pause"; sb.className="btn warn"; }
-    else if(status==="paused"){ lbl.textContent="Resume"; sb.className="btn primary"; }
-    else { lbl.textContent="Start event"; sb.className="btn primary"; }
-    if(e>=TOTAL){ $("#ctlPhase").textContent="Time — hands off"; $("#ctlStatus").textContent="60 minutes elapsed"; }
-    else if(status==="idle"){ $("#ctlPhase").textContent="Event not started"; $("#ctlStatus").textContent="Press “Start event” to run the 60 minutes for everyone"; }
-    else { $("#ctlPhase").textContent=ph.no+" · "+ph.name; $("#ctlStatus").textContent=(status==="paused"?"Paused · ":"Running · ")+fmtClock(ph.end*60-e)+" left in phase"; }
+    var open=isOpen(), started=Object.keys(teamClocks).length;
+    controlEl.classList.toggle("open", open);
+    $("#ctlTime").textContent = open ? "OPEN" : "CLOSED";
+    $("#ctlStartLabel").textContent = open ? "Close event" : "Open event";
+    $("#ctlStart").className = open ? "btn warn" : "btn primary";
+    $("#ctlPhase").textContent = open ? "Event is open" : "Event not started";
+    $("#ctlStatus").textContent = open
+      ? ("Opened "+fmtTime(eventDoc.openedAt)+" · "+started+" team"+(started===1?"":"s")+" started their clock")
+      : "Press “Open event” — each team then starts their own 60 minutes when they take their seats";
+    // per-team clocks on roster cards
+    var spans=document.querySelectorAll("[data-teamclock]");
+    for(var i=0;i<spans.length;i++){
+      var el=spans[i], tk=el.getAttribute("data-teamclock"), rem=teamRemaining(tk);
+      if(rem==null){ el.textContent="clock not started"; el.className="tclock idle"; }
+      else if(rem<=0){ el.textContent="⏱ time up"; el.className="tclock up"; }
+      else { el.textContent="⏱ "+fmtClock(rem)+" left"; el.className="tclock"+(rem<300?" low":""); }
+    }
   }
-  function writeCtl(doc){ if(!adapterRef){ alert("Not connected yet — try again in a moment."); return; } doc.id=ROOM; doc.room=ROOM; doc.updatedAt=Date.now(); ctl=doc; try{ adapterRef.write("control", doc); }catch(e){} renderControl(); }
+  function writeEvent(status){
+    if(!adapterRef){ alert("Not connected yet — try again in a moment."); return; }
+    var doc={ id:ROOM, room:ROOM, kind:"event", status:status, openedAt: status==="open" ? Date.now() : ((eventDoc&&eventDoc.openedAt)||Date.now()), updatedAt:Date.now() };
+    eventDoc=doc; try{ adapterRef.write("control", doc); }catch(e){} renderControl();
+  }
   $("#ctlStart").addEventListener("click", function(){
-    var status=(!ctl||ctl.status==="idle")?"idle":ctl.status, now=Date.now();
-    if(status==="idle"){ if(!confirm("Start the 60-minute clock now for ALL participants?")) return; writeCtl({status:"running",runId:now,startedAtMs:now,baseElapsedSec:0}); }
-    else if(status==="running"){ var base=(ctl.baseElapsedSec||0)+(now-(ctl.startedAtMs||now))/1000; writeCtl({status:"paused",runId:ctl.runId,startedAtMs:ctl.startedAtMs,baseElapsedSec:base}); }
-    else { writeCtl({status:"running",runId:ctl.runId,startedAtMs:now,baseElapsedSec:ctl.baseElapsedSec||0}); }
-  });
-  $("#ctlReset").addEventListener("click", function(){
-    if(!confirm("Reset the event clock to 00:00 for everyone? This re-seals the injections on all participant pages.")) return;
-    writeCtl({status:"idle",runId:0,startedAtMs:0,baseElapsedSec:0});
+    if(!isOpen()){ if(!confirm("Open the event now?\n\nTeams will be able to take their seats, and each team's own 60-minute clock starts when they register.")) return; writeEvent("open"); }
+    else { if(!confirm("Close the event?\n\nTeams that haven't started yet won't be able to begin. Teams already running keep their clocks.")) return; writeEvent("closed"); }
   });
   setInterval(renderControl,250); renderControl();
 
@@ -516,7 +527,12 @@
       adapter.watch("players", ROOM, function(d){ latest=d||[]; render(); });
       adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[tkey(s.teamName)]=s; }); render(); });
       adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
-      adapter.watch("control", ROOM, function(d){ ctl=(d&&d.length)?d[0]:null; renderControl(); });
+      adapter.watch("control", ROOM, function(d){
+        var docs=d||[]; eventDoc=docs.filter(function(x){ return x.id===ROOM; })[0]||null;
+        teamClocks={}; docs.forEach(function(x){ if(x.kind==="team" || (x.id&&x.id!==ROOM&&x.id.indexOf("__")>=0)) teamClocks[tkey(x.teamName)]=x; });
+        if(!eventDoc && !armedOnce){ armedOnce=true; writeEvent("closed"); } // arm the room so participants wait for "Open event"
+        renderControl();
+      });
     });
   } else {
     $("#statusText").textContent = "Roster unavailable";

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -596,6 +596,18 @@
 
   @media (max-width:520px){ .pm-roles{grid-template-columns:1fr} }
 
+  /* waiting-for-proctor overlay */
+  .wait-overlay{position:fixed;inset:0;z-index:450;display:flex;align-items:center;justify-content:center;padding:22px;background:linear-gradient(160deg,rgba(18,42,71,.97),rgba(10,24,48,.98));color:#EAF1F8;text-align:center}
+  .wait-overlay[hidden]{display:none}
+  .wo-card{max-width:460px}
+  .wo-card h2{font-size:26px;color:#fff;margin:8px 0 10px}
+  .wo-card p{font-size:14px;color:#AEC4DC;line-height:1.55}
+  .wo-card .pm-eyebrow{color:#7FE2EF}
+  .wo-card b{color:#fff}
+  .wo-spin{width:42px;height:42px;border-radius:50%;border:4px solid rgba(255,255,255,.18);border-top-color:var(--cyan);margin:0 auto 14px;animation:wospin 1s linear infinite}
+  @keyframes wospin{to{transform:rotate(360deg)}}
+  @media (prefers-reduced-motion:reduce){.wo-spin{animation:none}}
+
   /* --- focus / play view (hide reference sections during the hour) --- */
   body.focus-mode .ref-sec{display:none}
   body.focus-mode .toc a.ref-link{display:none}
@@ -640,6 +652,16 @@
   </div>
 </div>
 <div class="toast-wrap" id="toastWrap" aria-live="polite"></div>
+
+<!-- ============ WAITING-FOR-PROCTOR OVERLAY (interactive) ============ -->
+<div class="wait-overlay" id="waitOverlay" hidden>
+  <div class="wo-card">
+    <div class="wo-spin" aria-hidden="true"></div>
+    <div class="pm-eyebrow">Event not started</div>
+    <h2>Waiting for the proctor…</h2>
+    <p>The proctor hasn't opened the event yet. When they do, you'll see an <b>“Event opened”</b> message and be prompted to enter your team details — your team's 60 minutes begin the moment you take your seat.</p>
+  </div>
+</div>
 
 <!-- ============ PERSONA LOGIN (interactive) ============ -->
 <div class="persona-modal" id="personaModal" hidden role="dialog" aria-modal="true" aria-labelledby="pmTitle">
@@ -1818,44 +1840,65 @@
   }
   function primeFiredUpTo(e){ fired={}; CUES.forEach(function(c,i){ if(e>=c.sec) fired["cue"+i]=true; }); INJ.forEach(function(j,i){ if(e>=j.sec) fired["inj"+i]=true; }); }
 
-  // ---------- proctor-controlled clock (a proctor "starts the event for all") ----------
-  var proctorControlled=false, ctrl=null, primedForRun=null, ctrlTicker=null;
-  function elapsedFromCtrl(){
-    if(!ctrl || ctrl.status==="idle") return 0;
-    if(ctrl.status==="running") return Math.min(TOTAL, (ctrl.baseElapsedSec||0) + (Date.now()-(ctrl.startedAtMs||Date.now()))/1000);
-    return Math.min(TOTAL, ctrl.baseElapsedSec||0); // paused
+  // ---------- proctor-opened event + per-team clock ----------
+  // The proctor "opens" the event (control doc id=ROOM, status "open"). Each team's own
+  // 60 minutes starts when that team registers (control doc id=ROOM__<teamKey>, startedAt).
+  // While an event exists (managed), the participant's local timer buttons are locked.
+  var managed=false, eventOpen=false, prevEventOpen=false, teamStartedAt=null, evTicker=null, lastControlDocs=[];
+  function myTeamKey(){ return persona && persona.team ? persona.team.trim().toLowerCase() : null; }
+  function computeManagedElapsed(){
+    if(!managed || !eventOpen || !teamStartedAt) return 0;
+    return Math.min(TOTAL, (Date.now()-teamStartedAt)/1000);
   }
-  function updateControlUI(){
-    var b=$("#btnStart"), lbl=$("#btnStartLabel"), sk=$("#btnSkip"), rs=$("#btnReset");
-    if(proctorControlled){
+  function updateManagedUI(){
+    var b=$("#btnStart"), lbl=$("#btnStartLabel"), sk=$("#btnSkip"), rs=$("#btnReset"), ov=$("#waitOverlay");
+    if(managed){
       b.disabled=true; sk.disabled=true; rs.disabled=true;
-      b.title=sk.title=rs.title="The proctor controls the timer for everyone";
-      lbl.textContent = ctrl && ctrl.status==="running" ? "Live" : (ctrl && ctrl.status==="paused" ? "Paused" : "Waiting");
+      b.title=sk.title=rs.title="The proctor runs this event; your team clock starts when you take your seat";
+      lbl.textContent = !eventOpen ? "Waiting" : (teamStartedAt ? (computeManagedElapsed()<TOTAL?"Live":"Done") : "Take seat");
+      if(ov) ov.hidden = eventOpen;      // waiting overlay only while the event is closed
     } else {
       b.disabled=false; sk.disabled=false; rs.disabled=false;
+      if(ov) ov.hidden = true;
     }
   }
-  function controlledTick(){
-    elapsed=elapsedFromCtrl(); running=(ctrl && ctrl.status==="running");
-    render(); checkEvents(); updateControlUI();
+  function managedTick(){
+    elapsed=computeManagedElapsed(); running=(managed && eventOpen && !!teamStartedAt && elapsed<TOTAL);
+    render(); checkEvents(); updateManagedUI();
   }
-  function applyControl(doc){
-    if(!doc) return; // no central session -> stay in local mode
-    proctorControlled=true; ctrl=doc;
-    if(ticker){ clearInterval(ticker); ticker=null; } // local timer yields to the proctor
-    if(doc.status==="idle"){
-      if(primedForRun!=="idle"){ fired={}; INJ.forEach(function(j){ j.manual=false; }); toastWrap.innerHTML=""; primedForRun="idle"; }
-      elapsed=0;
-    } else if(primedForRun !== doc.runId){ // a new run started (or we just joined mid-run)
-      elapsed=elapsedFromCtrl();
-      primeFiredUpTo(elapsed);                 // don't replay past cues; future crossings still fire
-      INJ.forEach(function(j){ j.manual=false; });
-      if(elapsed<2){ toastWrap.innerHTML=""; toast("Session started","The proctor started the 60 minutes — Phase 0 · Brief-In begins now.","phase","00:00"); }
-      primedForRun=doc.runId;
+  function applyControlDocs(docs){
+    lastControlDocs = docs || [];
+    var ev = lastControlDocs.filter(function(x){ return x.id===ROOM; })[0] || null;
+    managed = !!ev; eventOpen = !!(ev && ev.status==="open");
+    var tk = myTeamKey();
+    var team = tk ? (lastControlDocs.filter(function(x){ return x.id===ROOM+"__"+tk; })[0] || null) : null;
+    var started = team ? team.startedAt : null;
+    if(started && started!==teamStartedAt){         // our team clock discovered / (re)started
+      teamStartedAt = started;
+      var e = Math.min(TOTAL,(Date.now()-teamStartedAt)/1000);
+      primeFiredUpTo(e); INJ.forEach(function(j){ j.manual=false; });
+      if(e<3){ toastWrap.innerHTML=""; toast("Your team clock started","60 minutes begin now — Phase 0 · Brief-In.","phase","00:00"); }
+    } else if(!started){ teamStartedAt=null; }
+    if(managed){
+      if(ticker){ clearInterval(ticker); ticker=null; } // local timer yields to the event
+      if(!evTicker) evTicker=setInterval(managedTick, 250);
+      if(eventOpen && !prevEventOpen){ toast("Event opened","The proctor opened the event — enter your team details to start your 60 minutes.","phase"); }
+      if(eventOpen && (!persona || !persona.role)) openPersona();
     }
-    elapsed=elapsedFromCtrl(); running=(doc.status==="running");
-    if(!ctrlTicker) ctrlTicker=setInterval(controlledTick, 250);
-    updateControlUI(); render(); checkEvents();
+    prevEventOpen = eventOpen;
+    elapsed=computeManagedElapsed(); running=(managed && eventOpen && !!teamStartedAt && elapsed<TOTAL);
+    updateManagedUI(); render(); checkEvents();
+  }
+  // start the team's clock (once) when a member takes their seat and the event is open
+  function ensureTeamClock(){
+    if(!roster || !managed || !eventOpen) return;
+    var tk = myTeamKey(); if(!tk) return;
+    if(lastControlDocs.some(function(x){ return x.id===ROOM+"__"+tk; })){ applyControlDocs(lastControlDocs); return; }
+    var doc={ id:ROOM+"__"+tk, room:ROOM, kind:"team", teamName:persona.team, startedAt:Date.now() };
+    try{ roster.write("control", doc); }catch(e){}
+    lastControlDocs.push(doc); teamStartedAt=doc.startedAt;
+    toastWrap.innerHTML=""; toast("Your team clock started","60 minutes begin now — Phase 0 · Brief-In.","phase","00:00");
+    updateManagedUI(); render();
   }
 
   // ---------- audio chimes ----------
@@ -1949,8 +1992,8 @@
       $("#barNext").textContent = fmt(leftInPhase)+" left in phase · "+nextTxt;
     }
 
-    // start button label (skipped while proctor-controlled — updateControlUI owns it)
-    if(!proctorControlled) $("#btnStartLabel").textContent = running ? "Pause" : (elapsed>0 && elapsed<TOTAL ? "Resume" : "Start");
+    // start button label (skipped while proctor-managed — updateManagedUI owns it)
+    if(!managed) $("#btnStartLabel").textContent = running ? "Pause" : (elapsed>0 && elapsed<TOTAL ? "Resume" : "Start");
 
     // board stops
     STOPS.forEach(function(s,i){
@@ -2010,13 +2053,13 @@
 
   // ---------- controls ----------
   $("#btnStart").addEventListener("click", function(){
-    if(proctorControlled) return;
+    if(managed) return;
     initAudio();
     if(running){ stop(); }
     else { if(elapsed===0) toast("Session started","60 minutes on the clock — Phase 0 · Brief-In begins now.","phase","00:00"); startTimer(); }
   });
   $("#btnSkip").addEventListener("click", function(){
-    if(proctorControlled) return;
+    if(managed) return;
     var idx=currentPhaseIndex();
     if(idx>=PHASES.length) return;
     var nextStart = (idx+1<=PHASES.length-1) ? PHASES[idx+1].start*60 : TOTAL;
@@ -2025,7 +2068,7 @@
     render(); checkEvents(); save();
   });
   $("#btnReset").addEventListener("click", function(){
-    if(proctorControlled) return;
+    if(managed) return;
     if(!confirm("Reset the session clock to 00:00 and re-seal all injections?\n\n(Your checklists and solution sheet are kept.)")) return;
     stop(); elapsed=0; fired={};
     INJ.forEach(function(j){ j.manual=false; });
@@ -2166,7 +2209,7 @@
     window.ZTDSRoster.init(ROOM).then(function(a){
       roster=a;
       if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.team){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
-      try{ roster.watch("control", ROOM, function(d){ var doc=(d&&d[0])||null; applyControl(doc); }); }catch(e){}
+      try{ roster.watch("control", ROOM, function(d){ applyControlDocs(d||[]); }); }catch(e){}
     });
   }
   var pl=$("#pmProctorLink"); if(pl) pl.href="proctor.html"+(ROOM!=="default"?("?room="+encodeURIComponent(ROOM)):"");
@@ -2248,11 +2291,13 @@
       if(!team){ pmTeam.classList.add("bad"); missing.push("a team name"); }
       if(missing.length){ showPmError("Please enter "+missing.join(", ")+" to join a team — or choose Facilitator / Observer to skip."); return; }
     }
+    if(managed && !eventOpen && key!=="facilitator"){ showPmError("The proctor hasn't opened the event yet — please wait for the “Event opened” message, then take your seat."); return; }
     hidePmError();
     persona={ role:key, name:name, email:email, team:team, joinedAt:Date.now() };
     try{ localStorage.setItem("ztds.persona", JSON.stringify(persona)); }catch(e){}
     applyPersona(); closePersona();
     if(roster && key!=="facilitator"){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
+    if(key!=="facilitator") ensureTeamClock();   // start (or join) this team's 60-minute clock
     toast("Seat taken", (name?esc(name)+", you":"You")+" are <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+".", "phase");
   }
   $("#btnPersona").addEventListener("click", openPersona);


### PR DESCRIPTION
## Summary

Reworks the shared timing into a **proctor-gated, per-team** model (replacing the single global clock).

## Behaviour

- **Proctor** (`proctor.html`): **Open event / Close event**. Opening the proctor page *arms* the room (so participants wait); **Open event** lets teams begin. The roster shows each team's live **time-remaining** clock and a "N teams started" count.
- **Participants** (`zero-trust-design-sprint.html`): before the event opens they see a **"Waiting for the proctor…"** overlay; when it opens they're prompted to **take their seat**. **A team's own 60-minute clock starts when the first teammate registers that team**, and teammates who join later adopt the same running clock. Each team's phases and injection reveals (24/38/50) run off *its own* clock. Local Start/Pause/Reset stay **locked** while an event is active; with no proctor event, the local timer still works (fallback).
- `firebase-config.js`: added `databaseURL` from the console (Firestore is still what's used; harmless). Docs (FACILITATOR, SETUP) updated.

## Firebase

No rules change needed — the existing `control` rule (any doc with a string `room`) already covers both the event document and per-team clock documents.

## Testing

End-to-end in headless Chromium: proctor arms room → participant shows Waiting + locked button → **Open event** → participant prompted → taking a seat starts the team clock (proctor shows "59:58 left", "1 team started") → a **second teammate adopts the running clock** (no reset, no duplicate). All three pages load with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_