### PR TITLE
Diagram upload, time-left nudges, and late-submission handling

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -37,8 +37,9 @@ the in-session phase/time cues live on the participant page itself.)
 
 ## After the clock (10 min)
 
-- [ ] Teams fill the solution sheet and click **Submit for scoring** (each team submits once; the last submit wins).
-- [ ] On **proctor**, each submitted team shows an **Evaluate** button → open it to read their solution and score **3 injections (10 each) + final solution (70) = 100**. Scores appear live on **`leaderboard.html`** (project it).
+- [ ] Teams fill the solution sheet, optionally **Attach diagram** (a photo of their topology), and click **Submit for scoring** (last submit wins). Participants get **5-min and 1-min** warnings automatically.
+- [ ] **Late is allowed:** teams can still submit after 60:00 — the submission records **total time taken** and is flagged **LATE +overtime** (not auto-penalized; you decide how to weigh it).
+- [ ] On **proctor**, each submitted team shows an **Evaluate** button → open it to see their **diagram + solution + time taken** and score **3 injections (10 each) + final solution (70) = 100**. Scores appear live on **`leaderboard.html`** (project it).
 - [ ] On **proctor**, click **Report** → **Print / Save as PDF** for a per-team record (now includes scores), or **Export CSV** for raw data.
 - [ ] Run the 10-minute debrief (reference design is in the participant page's Debrief section).
 

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -41,6 +41,7 @@
   .medal{font-size:24px;min-width:44px;text-align:center}
   .team{flex:1;min-width:0}
   .team .nm{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:19px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .team .nm .late{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:600;color:#fff;background:var(--red);border-radius:20px;padding:2px 8px;vertical-align:middle}
   .team .bd{font-family:"IBM Plex Mono",monospace;font-size:11.5px;color:var(--ink-faint);margin-top:2px}
   .bars{display:flex;gap:3px;margin-top:7px;max-width:320px}
   .bars i{height:6px;border-radius:3px;background:var(--line-soft)}
@@ -91,6 +92,7 @@
   var scores={}, solutions={};
   function esc(s){ return String(s==null?"":s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
   function tkey(t){ return (t==null?"":String(t)).trim().toLowerCase(); }
+  function fmtClock(s){ s=Math.max(0,Math.round(s)); var m=Math.floor(s/60),ss=s%60; return (m<10?"0":"")+m+":"+(ss<10?"0":"")+ss; }
   var MEDALS={1:"🥇",2:"🥈",3:"🥉"};
 
   function bars(n,max){ var out=""; for(var i=0;i<max;i++){ out+='<i class="'+(i<n?'f':'')+'" style="flex:1"></i>'; } return out; }
@@ -104,9 +106,12 @@
     board.innerHTML=list.map(function(s,i){
       var rank=i+1;
       var head = MEDALS[rank] ? ('<div class="medal">'+MEDALS[rank]+'</div>') : ('<div class="rank">'+rank+'</div>');
+      var sol = solutions[tkey(s.teamName)];
+      var lateTag = (sol && sol.late) ? ' <span class="late">LATE +'+fmtClock(sol.overtimeSec||0)+'</span>' : '';
+      var timeTag = (sol && sol.totalTimeSec!=null) ? '  ·  ⏱ '+fmtClock(sol.totalTimeSec) : '';
       return '<div class="row r'+rank+'">'+head+
-        '<div class="team"><div class="nm">'+esc(s.teamName||"—")+'</div>'+
-          '<div class="bd">Injections '+(s.i1||0)+' / '+(s.i2||0)+' / '+(s.i3||0)+'  ·  Solution '+(s.solution||0)+' / 70</div>'+
+        '<div class="team"><div class="nm">'+esc(s.teamName||"—")+lateTag+'</div>'+
+          '<div class="bd">Injections '+(s.i1||0)+' / '+(s.i2||0)+' / '+(s.i3||0)+'  ·  Solution '+(s.solution||0)+' / 70'+timeTag+'</div>'+
           '<div class="bars">'+bars((s.i1||0)+(s.i2||0)+(s.i3||0),30)+'</div>'+
         '</div>'+
         '<div class="total">'+(s.total||0)+'<small> / 100</small></div>'+

--- a/proctor.html
+++ b/proctor.html
@@ -118,6 +118,9 @@
   .score-row{display:flex;align-items:center;gap:9px;padding:10px 16px;border-top:1px solid var(--line-soft);background:#FAFCFF;flex-wrap:wrap}
   .score-row.muted{color:var(--ink-faint);font-family:"IBM Plex Mono",monospace;font-size:12px}
   .sub-badge{font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:#1f6e52;background:var(--green-soft,#D7F0E6);border:1px solid #A9DEC9;border-radius:20px;padding:3px 9px}
+  .time-badge{font-family:"IBM Plex Mono",monospace;font-size:10.5px;color:var(--ink-soft);background:#EEF3F9;border:1px solid var(--line-soft);border-radius:20px;padding:3px 9px}
+  .late-badge{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:600;color:#fff;background:var(--red);border-radius:20px;padding:3px 9px}
+  .em-diag{max-width:100%;max-height:300px;border-radius:10px;border:1px solid var(--line);display:block}
   .score-big{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:16px;color:var(--ink)}
   .score-big small{font-family:"IBM Plex Mono",monospace;font-weight:600;font-size:11px;color:var(--ink-faint)}
   .rank-badge{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:700;color:#fff;background:var(--navy);border-radius:20px;padding:3px 9px}
@@ -341,6 +344,8 @@
           '<button class="mini-btn re" data-eval="'+esc(tk)+'">Re-evaluate</button></div>';
       } else if(sol){
         footer = '<div class="score-row"><span class="sub-badge">Submitted '+fmtTime(sol.submittedAt)+'</span>'+
+          (sol.totalTimeSec!=null?'<span class="time-badge">took '+fmtClock(sol.totalTimeSec)+'</span>':'')+
+          (sol.late?'<span class="late-badge">LATE +'+fmtClock(sol.overtimeSec||0)+'</span>':'')+
           '<button class="mini-btn" data-eval="'+esc(tk)+'">Evaluate</button></div>';
       } else {
         footer = '<div class="score-row muted">No solution submitted yet</div>';
@@ -388,9 +393,10 @@
       var mem = g.members.map(function(p){
         return '<tr><td>'+esc(p.role||"—")+'</td><td>'+esc(p.name||"—")+'</td><td>'+esc(p.email||"")+'</td><td>'+fmtTime(p.joinedAt)+'</td></tr>';
       }).join("");
-      var sc=scores[key];
+      var sc=scores[key], sol=solutions[key];
       var scoreSpan = sc ? ' <span class="score">'+sc.total+'/100'+(ranks[key]?' · #'+ranks[key]:'')+'</span>' : '';
-      return '<div class="rt"><h3>'+esc(g.name)+' <span class="'+(missing.length?"bad":"ok")+'">'+(missing.length?("incomplete — missing "+missing.join(", ")):"complete")+'</span>'+scoreSpan+'</h3>'+
+      var timeSpan = (sol&&sol.totalTimeSec!=null) ? ' <span class="'+(sol.late?'bad':'ok')+'">took '+fmtClock(sol.totalTimeSec)+(sol.late?(' · LATE +'+fmtClock(sol.overtimeSec||0)):'')+'</span>' : '';
+      return '<div class="rt"><h3>'+esc(g.name)+' <span class="'+(missing.length?"bad":"ok")+'">'+(missing.length?("incomplete — missing "+missing.join(", ")):"complete")+'</span>'+scoreSpan+timeSpan+'</h3>'+
         '<table class="mt"><thead><tr><th>Role</th><th>Name</th><th>Email</th><th>Joined</th></tr></thead><tbody>'+mem+'</tbody></table></div>';
     }).join("");
     var roleLine = ["conductor","critic","architect","scribe","facilitator"].map(function(rk){ return ROLE_LABELS[rk]+": <b>"+(roleCounts[rk]||0)+"</b>"; }).join(" &nbsp;·&nbsp; ");
@@ -445,16 +451,23 @@
     var teamName = (sol&&sol.teamName) || (scores[tk]&&scores[tk].teamName) || tk;
     evalKey = tk;
     $("#emTeam").textContent = teamName;
-    $("#emMeta").textContent = sol ? ("Submitted "+fmtTime(sol.submittedAt)+(sol.submittedByName?(" · by "+sol.submittedByName):"")) : "No submission on record";
+    var meta = sol ? ("Submitted "+fmtTime(sol.submittedAt)+(sol.submittedByName?(" · by "+sol.submittedByName):"")+(sol.totalTimeSec!=null?(" · took "+fmtClock(sol.totalTimeSec)):"")+(sol.late?("  ⚠ LATE +"+fmtClock(sol.overtimeSec||0)):"")) : "No submission on record";
+    $("#emMeta").textContent = meta;
+    $("#emMeta").style.color = (sol&&sol.late) ? "var(--red)" : "";
     var solEl=$("#emSolution");
+    var parts=[];
+    if(sol && typeof sol.diagram==="string" && sol.diagram.indexOf("data:image")===0){
+      parts.push('<div class="em-field"><div class="k">Diagram</div><img class="em-diag" src="'+sol.diagram+'" alt="team diagram"></div>');
+    }
     if(sol && sol.fields && sol.fields.length){
-      solEl.innerHTML = sol.fields.map(function(f){
+      parts.push(sol.fields.map(function(f){
         var v=(f.value||"").trim();
         return '<div class="em-field"><div class="k">'+esc(f.label)+'</div><div class="v'+(v?'':' empty')+'">'+(v?esc(v):"— left blank —")+'</div></div>';
-      }).join("");
-    } else {
-      solEl.innerHTML = '<div class="em-field"><div class="v empty">This team hasn\'t submitted a solution sheet. You can still score from their diagram / discussion.</div></div>';
+      }).join(""));
+    } else if(!parts.length){
+      parts.push('<div class="em-field"><div class="v empty">This team hasn\'t submitted a solution sheet. You can still score from their diagram / discussion.</div></div>');
     }
+    solEl.innerHTML = parts.join("");
     $("#emI1").value = sc?sc.i1:""; $("#emI2").value = sc?sc.i2:""; $("#emI3").value = sc?sc.i3:"";
     $("#emSol").value = sc?sc.solution:""; $("#emNotes").value = sc?(sc.notes||""):"";
     emUpdateTotal();

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -520,6 +520,8 @@
   .st-btn.go{background:var(--green);border-color:var(--green);color:#fff}
   .st-btn.go:hover{background:#2cb583;border-color:#2cb583}
   .st-status{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--green);white-space:nowrap}
+  .diag-thumb{height:30px;width:44px;object-fit:cover;border-radius:6px;border:1px solid var(--line)}
+  .st-btn[data-diaglabel]{cursor:pointer}
   .st-btn{
     font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;letter-spacing:.04em;
     color:var(--ink);background:#F4F7FB;border:1px solid var(--line);border-radius:8px;
@@ -1837,8 +1839,11 @@
   function primeFired(){
     CUES.forEach(function(c,i){ if(elapsed>=c.sec) fired["cue"+i]=true; });
     INJ.forEach(function(j,i){ if(elapsed>=j.sec) fired["inj"+i]=true; });
+    if(elapsed>=TOTAL-300) fired["nudge5"]=true; if(elapsed>=TOTAL-60) fired["nudge1"]=true;
   }
-  function primeFiredUpTo(e){ fired={}; CUES.forEach(function(c,i){ if(e>=c.sec) fired["cue"+i]=true; }); INJ.forEach(function(j,i){ if(e>=j.sec) fired["inj"+i]=true; }); }
+  function primeFiredUpTo(e){ fired={}; CUES.forEach(function(c,i){ if(e>=c.sec) fired["cue"+i]=true; }); INJ.forEach(function(j,i){ if(e>=j.sec) fired["inj"+i]=true; }); if(e>=TOTAL-300) fired["nudge5"]=true; if(e>=TOTAL-60) fired["nudge1"]=true; }
+  // uncapped overtime (seconds past 60:00) for the team's running clock
+  function overtimeSec(){ if(managed && teamStartedAt){ return Math.max(0, Math.round((Date.now()-teamStartedAt)/1000 - TOTAL)); } return 0; }
 
   // ---------- proctor-opened event + per-team clock ----------
   // The proctor "opens" the event (control doc id=ROOM, status "open"). Each team's own
@@ -1979,8 +1984,9 @@
 
     // bar phase text
     if(elapsed>=TOTAL){
-      $("#barPhase").textContent="Time — hands off";
-      $("#barNext").textContent="Anything not submitted isn't scored · run the debrief";
+      var ot=overtimeSec();
+      $("#barPhase").textContent = ot>0 ? "Overtime" : "Time — hands off";
+      $("#barNext").textContent = ot>0 ? ("+"+fmt(ot)+" over 60:00 · you can still submit (marked late)") : "Submit if you haven't · run the debrief";
     } else if(!started){
       $("#barPhase").textContent="Press Start";
       $("#barNext").textContent="Phase 0 · Brief-In begins on start";
@@ -2027,6 +2033,9 @@
     INJ.forEach(function(j,i){
       if(elapsed>=j.sec && !fired["inj"+i]){ fired["inj"+i]=true; revealInjection(i); }
     });
+    // time-remaining nudges
+    if(elapsed>=TOTAL-300 && !fired["nudge5"]){ fired["nudge5"]=true; if(started){ toast("5 minutes left","Wrap up the current phase — start documenting and get ready to submit.","fire","05:00"); chime("fire"); } }
+    if(elapsed>=TOTAL-60 && elapsed<TOTAL && !fired["nudge1"]){ fired["nudge1"]=true; if(started){ toast("1 minute left","Photograph your diagram and submit now.","fire","01:00"); chime("fire"); } }
   }
 
   // ---------- ticking ----------
@@ -2121,6 +2130,9 @@
       '<button class="st-btn" data-copy><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 012-2h8"/></svg>Copy</button>'+
       '<button class="st-btn" data-print><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 9V3h12v6"/><rect x="4" y="9" width="16" height="8" rx="2"/><path d="M8 17h8v4H8z"/></svg>Print</button>'+
       '<button class="st-btn" data-clear><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 7h16M9 7V4h6v3M7 7l1 13h8l1-13"/></svg>Clear</button>'+
+      '<label class="st-btn" data-diaglabel><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="9" cy="11" r="2"/><path d="M3 17l5-4 4 3 3-2 6 5"/></svg>Attach diagram<input type="file" accept="image/*" data-diag hidden></label>'+
+      '<img class="diag-thumb" data-diagthumb alt="diagram" hidden>'+
+      '<button class="st-btn" data-diagclear hidden>✕</button>'+
       '<span class="st-status" data-substatus></span>'+
       '<button class="st-btn go" data-submit><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 12l5 5L20 6"/></svg>Submit for scoring</button>';
     body.insertBefore(tools, body.firstChild);
@@ -2159,15 +2171,56 @@
       document.body.appendChild(t); t.select(); try{ document.execCommand("copy"); }catch(e){} document.body.removeChild(t);
     }
 
+    // --- diagram photo attach (downscaled, stored with the submission) ---
+    var diagramDataUrl = null;
+    try{ diagramDataUrl = localStorage.getItem("ztds.diagram") || null; }catch(e){}
+    var diagInput=tools.querySelector("[data-diag]"), diagThumb=tools.querySelector("[data-diagthumb]"), diagClear=tools.querySelector("[data-diagclear]");
+    function showDiag(){
+      if(diagramDataUrl){ diagThumb.src=diagramDataUrl; diagThumb.hidden=false; diagClear.hidden=false; }
+      else { diagThumb.removeAttribute("src"); diagThumb.hidden=true; diagClear.hidden=true; }
+    }
+    function loadDiagram(file, cb){
+      var reader=new FileReader();
+      reader.onload=function(){
+        var img=new Image();
+        img.onload=function(){
+          var max=1000, w=img.width, h=img.height;
+          if(w>max||h>max){ if(w>=h){ h=Math.round(h*max/w); w=max; } else { w=Math.round(w*max/h); h=max; } }
+          var c=document.createElement("canvas"); c.width=w; c.height=h;
+          c.getContext("2d").drawImage(img,0,0,w,h);
+          var url=c.toDataURL("image/jpeg",0.7);
+          if(url.length>900000) url=c.toDataURL("image/jpeg",0.5);
+          cb(url);
+        };
+        img.onerror=function(){ cb(null); };
+        img.src=reader.result;
+      };
+      reader.onerror=function(){ cb(null); };
+      reader.readAsDataURL(file);
+    }
+    diagInput.addEventListener("change", function(){
+      var f=diagInput.files && diagInput.files[0]; if(!f) return;
+      loadDiagram(f, function(url){
+        if(!url){ toast("Couldn't read image","Try a different photo (JPG/PNG).","fire"); return; }
+        diagramDataUrl=url; try{ localStorage.setItem("ztds.diagram", url); }catch(e){}
+        showDiag(); toast("Diagram attached","It'll be sent to the proctor with your submission.","phase");
+      });
+      diagInput.value="";
+    });
+    diagClear.addEventListener("click", function(){ diagramDataUrl=null; try{ localStorage.removeItem("ztds.diagram"); }catch(e){} showDiag(); });
+    showDiag();
+
     // --- submit for scoring (sends the solution to the proctor via the shared store) ---
     var statusEl = tools.querySelector("[data-substatus]");
     var subBtn = tools.querySelector("[data-submit]");
     function teamKey(t){ return (t||"").trim().toLowerCase(); }
     function refreshSubmitStatus(){
       if(!persona || !persona.team){ statusEl.textContent=""; subBtn.lastChild.textContent="Submit for scoring"; return; }
-      var t=null; try{ t=localStorage.getItem("ztds.submittedAt."+teamKey(persona.team)); }catch(e){}
-      if(t){ statusEl.textContent="Submitted "+new Date(+t).toLocaleTimeString(); subBtn.lastChild.textContent="Re-submit for scoring"; }
-      else { statusEl.textContent=""; subBtn.lastChild.textContent="Submit for scoring"; }
+      var raw=null; try{ raw=localStorage.getItem("ztds.submitInfo."+teamKey(persona.team)); }catch(e){}
+      if(raw){ var s; try{ s=JSON.parse(raw); }catch(e){ s=null; }
+        if(s){ statusEl.textContent="Submitted "+new Date(s.at).toLocaleTimeString()+(s.late?(" · LATE +"+fmt(s.overtimeSec)):"")+" · took "+fmt(s.totalTimeSec); statusEl.style.color=s.late?"var(--red)":"var(--green)"; }
+        subBtn.lastChild.textContent="Re-submit for scoring";
+      } else { statusEl.textContent=""; subBtn.lastChild.textContent="Submit for scoring"; }
     }
     subBtn.addEventListener("click", function(){
       if(!persona || persona.role==="facilitator" || !persona.team){
@@ -2175,12 +2228,17 @@
       }
       if(!roster){ toast("Not connected yet","The scoring sync isn't ready — wait a moment and try again.","fire"); return; }
       var tk=teamKey(persona.team), when=Date.now();
+      // timing: total time on the team clock (uncapped), overtime past 60:00, late flag
+      var total = (managed && teamStartedAt) ? Math.round((when-teamStartedAt)/1000) : Math.round(elapsed);
+      total=Math.max(0,total); var over=Math.max(0,total-TOTAL), late=total>TOTAL;
       var doc={ id:ROOM+"__"+tk, room:ROOM, teamName:persona.team, submittedByName:persona.name||"", submittedAt:when,
+                totalTimeSec:total, overtimeSec:over, late:late, diagram: diagramDataUrl||"",
                 fields: inputs.map(function(x){ return { label:x.label, value:x.ta.value.trim() }; }) };
       try{ roster.write("solutions", doc); }catch(e){}
-      try{ localStorage.setItem("ztds.submittedAt."+tk, String(when)); }catch(e){}
+      try{ localStorage.setItem("ztds.submitInfo."+tk, JSON.stringify({at:when,totalTimeSec:total,overtimeSec:over,late:late})); }catch(e){}
       refreshSubmitStatus();
-      toast("Submitted for scoring","Your team’s solution was sent to the proctor. You can edit and re-submit until it’s scored.","phase");
+      if(late) toast("Submitted — marked late","Recorded at "+fmt(total)+" (+"+fmt(over)+" over 60:00). You can still edit and re-submit.","fire");
+      else toast("Submitted for scoring","Sent to the proctor in "+fmt(total)+". You can edit and re-submit until it’s scored.","phase");
     });
     setTimeout(refreshSubmitStatus, 0);
   }


### PR DESCRIPTION
## Summary

Three product-polish additions requested for the clinic.

### 6 · Diagram capture for scoring
Participants can **Attach diagram** (a photo of their topology) on the solution sheet. It's downscaled client-side (≤1000px JPEG, kept well under Firestore's 1 MB doc limit) and stored with the submission. The proctor's **Evaluate** modal shows the image alongside the sheet.

### 8 · Time-left nudges
Automatic **5-minute** and **1-minute** warnings (toast + chime) off each team's own clock. Primed on join so a late arrival doesn't get a burst of past warnings.

### 7 · Late submissions (reworked per request)
Submission is **never blocked**. Submitting records the team's **total time taken**; if past 60:00 it also records the **overtime** and sets a **late** flag. Surfaced everywhere:
- Participant: bar shows **Overtime +MM:SS**; submit status shows time taken and a late mark.
- Proctor: team card + evaluate modal + printable report show **time taken** and a **LATE +overtime** badge.
- Leaderboard: rows show ⏱ time taken and a LATE tag.

Scores are **not** auto-penalized — the flag is informational, as asked ("remark late submission only for the moment").

## Firebase
No rules change — the extra fields live on the existing `solutions` documents.

## Testing
Headless Chromium: diagram attaches, is stored as an image, and renders in the proctor modal; a late submission records overtime (~114s over) and is flagged; the 5-minute nudge fires on a live clock crossing. All three pages load with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_