### PR TITLE
Add a login/lobby phase; proctor starts one clock for everyone

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -20,20 +20,19 @@ the in-session phase/time cues live on the participant page itself.)
 - [ ] Share the **participant** link / QR with the room.
 - [ ] Decide team names in advance (or let each table choose one) so people group correctly.
 
-## As people arrive (5 min)
+## Logging everyone in (5 min)
 
-- [ ] Participants who open the link **before you open the event** see a **"Waiting for the proctor…"** screen — that's expected.
-- [ ] When ready, on **`proctor.html`** press **Open event**. Everyone's waiting screen clears and they're prompted to take their seat.
-- [ ] Each person clicks **Take your seat**: name, email, **team name**, role. **The team's own 60-minute clock starts the moment the first teammate registers** — so a team begins when *they* are ready; teammates who join after start on the same running clock.
-- [ ] Watch teams appear on your **proctor** screen, grouped by team, each showing a live **⏱ time-left** clock. Use the **summary** to spot gaps (each team should show **4/4 roles**).
+- [ ] Participants who open the link **before you open registration** see a **"Waiting for the proctor…"** screen — that's expected.
+- [ ] On **`proctor.html`** press **Open for login**. Everyone's waiting screen clears and they're prompted to take their seat.
+- [ ] Each person clicks **Take your seat**: name, email, **team name**, role — then they sit in a **lobby** (clock at 00:00) until you start it.
+- [ ] Watch the proctor **Event control** readout fill in: **"N logged in · T teams · K/T complete (4 roles)."** Nudge teams to fill missing roles.
 
-## Running the hour (per-team 60 min)
+## Starting the clock
 
-- [ ] *(Optional)* Ask teams to press **Focus** in their control bar to hide reference sections — cuts on-page reading ~in half. Toggle **Show all** anytime.
-- [ ] Each team's board, phases, and **injection reveals (24/38/50 min)** run off **their own** clock — teams that started later reach each phase later. The proctor roster shows every team's remaining time.
-- [ ] The in-game **Conductor** on each team keeps their table on pace; you float between tables.
-- [ ] Participants' local Start/Pause is **locked** while the event is open — the clock is automatic per team.
-- [ ] Press **Close event** when you want to stop new teams from starting (teams already running keep their clocks). Keep the **proctor** tab open to watch the roster and clocks throughout.
+- [ ] When everyone's in, press **Start clock** on the proctor. This starts the **single 60-minute clock for all teams at once**; every participant's board begins Phase 0 together.
+- [ ] *(Optional)* Ask teams to press **Focus** to hide reference sections — cuts on-page reading ~in half.
+- [ ] Boards, phases, and **injection reveals (24/38/50 min)** run off the shared clock; participants get **5-min and 1-min** warnings automatically. Participants' local Start/Pause is **locked**.
+- [ ] Use **Pause / Resume** on the proctor to hold the whole room; **Reset** sends everyone back to the lobby at 00:00. Keep the proctor tab open to watch the roster throughout.
 
 ## After the clock (10 min)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -114,12 +114,12 @@ Troubleshooting:
 
 - **Multiple rooms/cohorts:** add `?room=CODE` to *both* page URLs to scope a roster to one
   session, e.g. `…/proctor.html?room=june-cohort` and `…/zero-trust-design-sprint.html?room=june-cohort`.
-- **Opening the event:** on `proctor.html`, press **Open event**. Until then, participants see a
-  "Waiting for the proctor…" screen. Once open, each team's own 60-minute clock starts when that
-  team takes their seats — so teams can begin at their own pace, and each team's phases and
-  injection reveals run off their own clock. The proctor roster shows every team's time remaining.
-  Press **Close event** to stop new teams from starting. *(If no proctor opens an event, a
-  participant page falls back to a local self-run timer.)*
+- **Two-phase start:** on `proctor.html`, press **Open for login** — participants (who until then
+  see a "Waiting for the proctor…" screen) can now take their seats and sit in a **lobby** at
+  00:00. The proctor shows a readiness readout ("N logged in · T teams · K/T complete"). When
+  everyone's in, press **Start clock** to begin the **single 60-minute clock for all teams at
+  once**. **Pause/Resume** holds the room; **Reset** returns everyone to the lobby. *(If no proctor
+  opens an event, a participant page falls back to a local self-run timer.)*
 - **Reports:** on `proctor.html`, use **Export CSV** for raw data or **Report** for a printable
   (PDF-ready) participant summary with per-team completeness. Scales to ~300 participants.
 - **Scoring & leaderboard:** teams click **Submit for scoring** on the participant page (after

--- a/proctor.html
+++ b/proctor.html
@@ -188,9 +188,10 @@
 
   <div class="control" id="control">
     <div class="ctl-clock"><span class="ctl-time" id="ctlTime">CLOSED</span></div>
-    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event not started</span><span class="ctl-status" id="ctlStatus">Press “Open event” — each team then starts their own 60 minutes when they take their seats</span></div>
+    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event not started</span><span class="ctl-status" id="ctlStatus">Press “Open for login” — players register, then you start the clock for everyone</span></div>
     <div class="ctl-btns">
-      <button class="btn primary" id="ctlStart"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M5 12l5 5L20 7"/></svg><span id="ctlStartLabel">Open event</span></button>
+      <button class="btn primary" id="ctlStart"><span id="ctlStartLabel">Open for login</span></button>
+      <button class="btn" id="ctlReset" hidden>Reset</button>
     </div>
   </div>
 
@@ -350,10 +351,9 @@
       } else {
         footer = '<div class="score-row muted">No solution submitted yet</div>';
       }
-      var clockLine = '<div class="clock-row"><span class="tclock idle" data-teamclock="'+esc(tk)+'">clock not started</span></div>';
-      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+clockLine+rows+missHtml+footer+'</div>';
+      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+rows+missHtml+footer+'</div>';
     }).join("");
-    renderControl(); // refresh per-team clock spans right after rebuild
+    renderControl(); // refresh lobby readiness counts after roster rebuild
   }
 
   function toCsv(){
@@ -494,38 +494,46 @@
     if(btn) openEval(btn.getAttribute("data-eval"));
   });
 
-  // ---------- event control: proctor opens the event; each team runs its own clock ----------
-  var TOTAL=3600, eventDoc=null, teamClocks={}, controlEl=$("#control"), armedOnce=false;
+  // ---------- event control: open for login, then one global clock for everyone ----------
+  var TOTAL=3600, eventDoc=null, controlEl=$("#control"), armedOnce=false;
+  var PHASES=[{no:"PHASE 0",name:"Brief-In",end:8,color:"#E2891F"},{no:"PHASE 1",name:"Expose",end:20,color:"#DB4A4A"},{no:"PHASE 2",name:"Decide",end:33,color:"#0FA9BE"},{no:"PHASE 3",name:"Design",end:48,color:"#2a6fb0"},{no:"PHASE 4",name:"Document",end:56,color:"#27A276"},{no:"PHASE 5",name:"Submit",end:60,color:"#122A47"}];
   function fmtClock(s){ s=Math.max(0,Math.round(s)); var m=Math.floor(s/60),ss=s%60; return (m<10?"0":"")+m+":"+(ss<10?"0":"")+ss; }
-  function isOpen(){ return !!(eventDoc && eventDoc.status==="open"); }
-  function teamRemaining(tk){ var t=teamClocks[tk]; if(!t||!t.startedAt) return null; return Math.max(0, TOTAL-(Date.now()-t.startedAt)/1000); }
+  function evStat(){ return eventDoc ? (eventDoc.status||"closed") : "closed"; }
+  function evElapsed(){ var s=evStat(); if(s==="running") return Math.min(TOTAL,(eventDoc.baseElapsedSec||0)+(Date.now()-(eventDoc.startedAtMs||Date.now()))/1000); if(s==="paused") return Math.min(TOTAL,eventDoc.baseElapsedSec||0); return 0; }
+  function phaseAt(e){ if(e>=TOTAL) return null; for(var i=0;i<PHASES.length;i++){ if(e<PHASES[i].end*60) return PHASES[i]; } return PHASES[PHASES.length-1]; }
+  function readiness(){ var g=groupBy(latest); var complete=g.order.filter(function(k){ return isComplete(g.groups[k].members); }).length; return { players:latest.length, teams:g.order.length, complete:complete }; }
   function renderControl(){
-    var open=isOpen(), started=Object.keys(teamClocks).length;
-    controlEl.classList.toggle("open", open);
-    $("#ctlTime").textContent = open ? "OPEN" : "CLOSED";
-    $("#ctlStartLabel").textContent = open ? "Close event" : "Open event";
-    $("#ctlStart").className = open ? "btn warn" : "btn primary";
-    $("#ctlPhase").textContent = open ? "Event is open" : "Event not started";
-    $("#ctlStatus").textContent = open
-      ? ("Opened "+fmtTime(eventDoc.openedAt)+" · "+started+" team"+(started===1?"":"s")+" started their clock")
-      : "Press “Open event” — each team then starts their own 60 minutes when they take their seats";
-    // per-team clocks on roster cards
-    var spans=document.querySelectorAll("[data-teamclock]");
-    for(var i=0;i<spans.length;i++){
-      var el=spans[i], tk=el.getAttribute("data-teamclock"), rem=teamRemaining(tk);
-      if(rem==null){ el.textContent="clock not started"; el.className="tclock idle"; }
-      else if(rem<=0){ el.textContent="⏱ time up"; el.className="tclock up"; }
-      else { el.textContent="⏱ "+fmtClock(rem)+" left"; el.className="tclock"+(rem<300?" low":""); }
+    var s=evStat(), e=evElapsed(), ph=phaseAt(e), running=(s==="running"||s==="paused");
+    controlEl.classList.toggle("open", s!=="closed");
+    controlEl.style.setProperty("--pc", running?(e>=TOTAL?"#122A47":(ph?ph.color:"#0FA9BE")):"#0FA9BE");
+    var lbl=$("#ctlStartLabel"), sb=$("#ctlStart"), rb=$("#ctlReset");
+    if(s==="closed"){ $("#ctlTime").textContent="CLOSED"; lbl.textContent="Open for login"; sb.className="btn primary"; rb.hidden=true;
+      $("#ctlPhase").textContent="Event not started"; $("#ctlStatus").textContent="Press “Open for login” — players register, then you start the clock for everyone"; }
+    else if(s==="login"){ var r=readiness(); $("#ctlTime").textContent="LOBBY"; lbl.textContent="Start clock"; sb.className="btn primary"; rb.hidden=false; rb.textContent="Close";
+      $("#ctlPhase").textContent="Registration open — lobby"; $("#ctlStatus").textContent=r.players+" logged in · "+r.teams+" teams · "+r.complete+"/"+r.teams+" complete (4 roles) — press “Start clock” when ready"; }
+    else { // running or paused
+      $("#ctlTime").textContent=fmtClock(e); lbl.textContent = s==="running"?"Pause":"Resume"; sb.className = s==="running"?"btn warn":"btn primary"; rb.hidden=false; rb.textContent="Reset";
+      if(e>=TOTAL){ $("#ctlPhase").textContent="Time — hands off"; $("#ctlStatus").textContent="60 minutes elapsed"; }
+      else { $("#ctlPhase").textContent=ph.no+" · "+ph.name; $("#ctlStatus").textContent=(s==="paused"?"Paused · ":"Running · ")+fmtClock(ph.end*60-e)+" left in phase"; }
     }
   }
-  function writeEvent(status){
+  function writeEvent(patch){
     if(!adapterRef){ alert("Not connected yet — try again in a moment."); return; }
-    var doc={ id:ROOM, room:ROOM, kind:"event", status:status, openedAt: status==="open" ? Date.now() : ((eventDoc&&eventDoc.openedAt)||Date.now()), updatedAt:Date.now() };
+    var base=eventDoc||{ id:ROOM, room:ROOM };
+    var doc=Object.assign({}, base, patch, { id:ROOM, room:ROOM, kind:"event", updatedAt:Date.now() });
     eventDoc=doc; try{ adapterRef.write("control", doc); }catch(e){} renderControl();
   }
   $("#ctlStart").addEventListener("click", function(){
-    if(!isOpen()){ if(!confirm("Open the event now?\n\nTeams will be able to take their seats, and each team's own 60-minute clock starts when they register.")) return; writeEvent("open"); }
-    else { if(!confirm("Close the event?\n\nTeams that haven't started yet won't be able to begin. Teams already running keep their clocks.")) return; writeEvent("closed"); }
+    var s=evStat(), now=Date.now();
+    if(s==="closed"){ if(!confirm("Open registration now? Players can take their seats; the clock stays at 00:00 until you start it.")) return; writeEvent({status:"login", openedAt:now}); }
+    else if(s==="login"){ var r=readiness(); if(!confirm("Start the 60-minute clock now for ALL "+r.players+" players / "+r.teams+" teams?\n\n"+r.complete+" of "+r.teams+" teams have all 4 roles.")) return; writeEvent({status:"running", runId:now, startedAtMs:now, baseElapsedSec:0}); }
+    else if(s==="running"){ var base=(eventDoc.baseElapsedSec||0)+(now-(eventDoc.startedAtMs||now))/1000; writeEvent({status:"paused", baseElapsedSec:base}); }
+    else { writeEvent({status:"running", startedAtMs:now}); }
+  });
+  $("#ctlReset").addEventListener("click", function(){
+    var s=evStat();
+    if(s==="login"){ if(!confirm("Close the event back to the waiting screen? Players will wait again.")) return; writeEvent({status:"closed"}); }
+    else { if(!confirm("Reset the clock to 00:00 and send everyone back to the lobby?")) return; writeEvent({status:"login", runId:0, startedAtMs:0, baseElapsedSec:0}); }
   });
   setInterval(renderControl,250); renderControl();
 
@@ -542,8 +550,7 @@
       adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
       adapter.watch("control", ROOM, function(d){
         var docs=d||[]; eventDoc=docs.filter(function(x){ return x.id===ROOM; })[0]||null;
-        teamClocks={}; docs.forEach(function(x){ if(x.kind==="team" || (x.id&&x.id!==ROOM&&x.id.indexOf("__")>=0)) teamClocks[tkey(x.teamName)]=x; });
-        if(!eventDoc && !armedOnce){ armedOnce=true; writeEvent("closed"); } // arm the room so participants wait for "Open event"
+        if(!eventDoc && !armedOnce){ armedOnce=true; writeEvent({status:"closed"}); } // arm the room so participants wait
         renderControl();
       });
     });

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -661,7 +661,7 @@
     <div class="wo-spin" aria-hidden="true"></div>
     <div class="pm-eyebrow">Event not started</div>
     <h2>Waiting for the proctor…</h2>
-    <p>The proctor hasn't opened the event yet. When they do, you'll see an <b>“Event opened”</b> message and be prompted to enter your team details — your team's 60 minutes begin the moment you take your seat.</p>
+    <p>The proctor hasn't opened registration yet. When they do, you'll be prompted to <b>take your seat</b> (name, email, team, role). Everyone logs in first — then the proctor starts the clock and all teams' 60 minutes begin together.</p>
   </div>
 </div>
 
@@ -1842,68 +1842,64 @@
     if(elapsed>=TOTAL-300) fired["nudge5"]=true; if(elapsed>=TOTAL-60) fired["nudge1"]=true;
   }
   function primeFiredUpTo(e){ fired={}; CUES.forEach(function(c,i){ if(e>=c.sec) fired["cue"+i]=true; }); INJ.forEach(function(j,i){ if(e>=j.sec) fired["inj"+i]=true; }); if(e>=TOTAL-300) fired["nudge5"]=true; if(e>=TOTAL-60) fired["nudge1"]=true; }
-  // uncapped overtime (seconds past 60:00) for the team's running clock
-  function overtimeSec(){ if(managed && teamStartedAt){ return Math.max(0, Math.round((Date.now()-teamStartedAt)/1000 - TOTAL)); } return 0; }
-
-  // ---------- proctor-opened event + per-team clock ----------
-  // The proctor "opens" the event (control doc id=ROOM, status "open"). Each team's own
-  // 60 minutes starts when that team registers (control doc id=ROOM__<teamKey>, startedAt).
+  // ---------- proctor-run event: login phase, then one global clock ----------
+  // Control doc (id=ROOM) status: "closed" (armed, waiting) -> "login" (registration open,
+  // no clock yet) -> "running" (global 60-min clock from startedAtMs) -> "paused".
   // While an event exists (managed), the participant's local timer buttons are locked.
-  var managed=false, eventOpen=false, prevEventOpen=false, teamStartedAt=null, evTicker=null, lastControlDocs=[];
-  function myTeamKey(){ return persona && persona.team ? persona.team.trim().toLowerCase() : null; }
-  function computeManagedElapsed(){
-    if(!managed || !eventOpen || !teamStartedAt) return 0;
-    return Math.min(TOTAL, (Date.now()-teamStartedAt)/1000);
+  var managed=false, evStatus="closed", startedAtMs=0, baseElapsedSec=0, primedForRun=null, evTicker=null, lastControlDocs=[], eventDoc=null;
+  function evElapsed(){
+    if(evStatus==="running") return Math.min(TOTAL, (baseElapsedSec||0)+(Date.now()-(startedAtMs||Date.now()))/1000);
+    if(evStatus==="paused") return Math.min(TOTAL, baseElapsedSec||0);
+    return 0; // closed / login
+  }
+  function overtimeSec(){
+    if(managed && (evStatus==="running"||evStatus==="paused")){
+      var t=(evStatus==="running") ? (baseElapsedSec+(Date.now()-startedAtMs)/1000) : baseElapsedSec;
+      return Math.max(0, Math.round(t-TOTAL));
+    }
+    return 0;
   }
   function updateManagedUI(){
     var b=$("#btnStart"), lbl=$("#btnStartLabel"), sk=$("#btnSkip"), rs=$("#btnReset"), ov=$("#waitOverlay");
     if(managed){
       b.disabled=true; sk.disabled=true; rs.disabled=true;
-      b.title=sk.title=rs.title="The proctor runs this event; your team clock starts when you take your seat";
-      lbl.textContent = !eventOpen ? "Waiting" : (teamStartedAt ? (computeManagedElapsed()<TOTAL?"Live":"Done") : "Take seat");
-      if(ov) ov.hidden = eventOpen;      // waiting overlay only while the event is closed
+      b.title=sk.title=rs.title="The proctor runs the clock for this event";
+      lbl.textContent = evStatus==="running"?"Live":(evStatus==="paused"?"Paused":(evStatus==="login"?"Lobby":"Waiting"));
+      if(ov) ov.hidden = (evStatus!=="closed");   // full waiting overlay only before registration opens
     } else {
       b.disabled=false; sk.disabled=false; rs.disabled=false;
       if(ov) ov.hidden = true;
     }
   }
   function managedTick(){
-    elapsed=computeManagedElapsed(); running=(managed && eventOpen && !!teamStartedAt && elapsed<TOTAL);
+    elapsed=evElapsed(); running=(evStatus==="running" && elapsed<TOTAL);
     render(); checkEvents(); updateManagedUI();
   }
   function applyControlDocs(docs){
     lastControlDocs = docs || [];
-    var ev = lastControlDocs.filter(function(x){ return x.id===ROOM; })[0] || null;
-    managed = !!ev; eventOpen = !!(ev && ev.status==="open");
-    var tk = myTeamKey();
-    var team = tk ? (lastControlDocs.filter(function(x){ return x.id===ROOM+"__"+tk; })[0] || null) : null;
-    var started = team ? team.startedAt : null;
-    if(started && started!==teamStartedAt){         // our team clock discovered / (re)started
-      teamStartedAt = started;
-      var e = Math.min(TOTAL,(Date.now()-teamStartedAt)/1000);
-      primeFiredUpTo(e); INJ.forEach(function(j){ j.manual=false; });
-      if(e<3){ toastWrap.innerHTML=""; toast("Your team clock started","60 minutes begin now — Phase 0 · Brief-In.","phase","00:00"); }
-    } else if(!started){ teamStartedAt=null; }
+    eventDoc = lastControlDocs.filter(function(x){ return x.id===ROOM; })[0] || null;
+    managed = !!eventDoc;
+    var prev = evStatus;
+    evStatus = eventDoc ? (eventDoc.status||"closed") : "closed";
+    startedAtMs = eventDoc ? (eventDoc.startedAtMs||0) : 0;
+    baseElapsedSec = eventDoc ? (eventDoc.baseElapsedSec||0) : 0;
     if(managed){
       if(ticker){ clearInterval(ticker); ticker=null; } // local timer yields to the event
       if(!evTicker) evTicker=setInterval(managedTick, 250);
-      if(eventOpen && !prevEventOpen){ toast("Event opened","The proctor opened the event — enter your team details to start your 60 minutes.","phase"); }
-      if(eventOpen && (!persona || !persona.role)) openPersona();
+      if(evStatus==="login" && prev==="closed"){ toast("Registration open","The proctor opened the event — take your seat. The clock starts once everyone's in.","phase"); }
+      if(evStatus==="login" && (!persona || !persona.role)) openPersona();
+      if(evStatus==="running"){
+        if(primedForRun !== eventDoc.runId){
+          var e=evElapsed(); primeFiredUpTo(e); INJ.forEach(function(j){ j.manual=false; });
+          if(e<3){ toastWrap.innerHTML=""; toast("Clock started","The proctor started the 60 minutes — Phase 0 · Brief-In begins now.","phase","00:00"); }
+          primedForRun = eventDoc.runId;
+        }
+      } else if((evStatus==="login"||evStatus==="closed") && (prev==="running"||prev==="paused")){
+        fired={}; INJ.forEach(function(j){ j.manual=false; }); toastWrap.innerHTML=""; primedForRun=null; // clock reset back to lobby
+      }
     }
-    prevEventOpen = eventOpen;
-    elapsed=computeManagedElapsed(); running=(managed && eventOpen && !!teamStartedAt && elapsed<TOTAL);
+    elapsed=evElapsed(); running=(evStatus==="running" && elapsed<TOTAL);
     updateManagedUI(); render(); checkEvents();
-  }
-  // start the team's clock (once) when a member takes their seat and the event is open
-  function ensureTeamClock(){
-    if(!roster || !managed || !eventOpen) return;
-    var tk = myTeamKey(); if(!tk) return;
-    if(lastControlDocs.some(function(x){ return x.id===ROOM+"__"+tk; })){ applyControlDocs(lastControlDocs); return; }
-    var doc={ id:ROOM+"__"+tk, room:ROOM, kind:"team", teamName:persona.team, startedAt:Date.now() };
-    try{ roster.write("control", doc); }catch(e){}
-    lastControlDocs.push(doc); teamStartedAt=doc.startedAt;
-    toastWrap.innerHTML=""; toast("Your team clock started","60 minutes begin now — Phase 0 · Brief-In.","phase","00:00");
-    updateManagedUI(); render();
   }
 
   // ---------- audio chimes ----------
@@ -1983,7 +1979,10 @@
     bar.style.setProperty("--pc", col);
 
     // bar phase text
-    if(elapsed>=TOTAL){
+    if(managed && (evStatus==="login"||evStatus==="closed")){
+      $("#barPhase").textContent = evStatus==="login" ? "Lobby" : "Waiting";
+      $("#barNext").textContent = evStatus==="login" ? "Logged in — waiting for the proctor to start the clock" : "Waiting for the proctor to open registration";
+    } else if(elapsed>=TOTAL){
       var ot=overtimeSec();
       $("#barPhase").textContent = ot>0 ? "Overtime" : "Time — hands off";
       $("#barNext").textContent = ot>0 ? ("+"+fmt(ot)+" over 60:00 · you can still submit (marked late)") : "Submit if you haven't · run the debrief";
@@ -2228,9 +2227,11 @@
       }
       if(!roster){ toast("Not connected yet","The scoring sync isn't ready — wait a moment and try again.","fire"); return; }
       var tk=teamKey(persona.team), when=Date.now();
-      // timing: total time on the team clock (uncapped), overtime past 60:00, late flag
-      var total = (managed && teamStartedAt) ? Math.round((when-teamStartedAt)/1000) : Math.round(elapsed);
-      total=Math.max(0,total); var over=Math.max(0,total-TOTAL), late=total>TOTAL;
+      // timing: total time on the clock (uncapped), overtime past 60:00, late flag
+      var total;
+      if(managed && (evStatus==="running"||evStatus==="paused")){ total = (baseElapsedSec||0) + (evStatus==="running" ? (when-startedAtMs)/1000 : 0); }
+      else { total = elapsed; }
+      total=Math.max(0,Math.round(total)); var over=Math.max(0,total-TOTAL), late=total>TOTAL;
       var doc={ id:ROOM+"__"+tk, room:ROOM, teamName:persona.team, submittedByName:persona.name||"", submittedAt:when,
                 totalTimeSec:total, overtimeSec:over, late:late, diagram: diagramDataUrl||"",
                 fields: inputs.map(function(x){ return { label:x.label, value:x.ta.value.trim() }; }) };
@@ -2349,14 +2350,15 @@
       if(!team){ pmTeam.classList.add("bad"); missing.push("a team name"); }
       if(missing.length){ showPmError("Please enter "+missing.join(", ")+" to join a team — or choose Facilitator / Observer to skip."); return; }
     }
-    if(managed && !eventOpen && key!=="facilitator"){ showPmError("The proctor hasn't opened the event yet — please wait for the “Event opened” message, then take your seat."); return; }
+    if(managed && evStatus==="closed" && key!=="facilitator"){ showPmError("The proctor hasn't opened registration yet — please wait for the “Registration open” message, then take your seat."); return; }
     hidePmError();
     persona={ role:key, name:name, email:email, team:team, joinedAt:Date.now() };
     try{ localStorage.setItem("ztds.persona", JSON.stringify(persona)); }catch(e){}
     applyPersona(); closePersona();
     if(roster && key!=="facilitator"){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
-    if(key!=="facilitator") ensureTeamClock();   // start (or join) this team's 60-minute clock
-    toast("Seat taken", (name?esc(name)+", you":"You")+" are <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+".", "phase");
+    updateManagedUI();
+    if(managed && key!=="facilitator") toast("You're in the lobby", "Logged in as <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+". The clock starts when the proctor starts it.", "phase");
+    else toast("Seat taken", (name?esc(name)+", you":"You")+" are <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+".", "phase");
   }
   $("#btnPersona").addEventListener("click", openPersona);
   $("#pmClose").addEventListener("click", closePersona);


### PR DESCRIPTION
## Summary

Changes the timing so the clock starts **after all players log in**: the proctor opens registration, everyone joins a lobby, then the proctor starts one shared 60-minute clock for all teams at once.

## Behaviour

- **Control event states:** `closed` → `login` → `running` → `paused`.
- **Proctor** (`proctor.html`): **Open for login** → **Start clock** (with a readiness readout — *"N logged in · T teams · K/T complete (4 roles)"*) → **Pause/Resume**, and **Reset** (back to lobby).
- **Participants** (`zero-trust-design-sprint.html`): a "Waiting for the proctor…" overlay only before login opens; after taking a seat they sit in a **lobby** (clock 00:00) until the proctor starts; then all clocks run off the shared start. Local timer stays locked while managed; falls back to a local self-run timer when no proctor event exists.
- Replaces the previous per-team clock (each team started on registration) with a single global clock gated behind the login phase. Submission timing / overtime / late flag now read the global clock.

## Firebase
No rules change — still one `control` document per room (now with the login/running states).

## Testing
Headless Chromium: arm → Waiting; **Open for login** → lobby + seat prompt; take seat → lobby at 00:00 with the readiness count updating; **Start clock** → all participants go Live together with Phase 0 active; **Pause** freezes; **Reset** returns everyone to the lobby. All three pages load with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_