### PR TITLE
Named/scheduled events with event codes and per-team join codes

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -3,36 +3,35 @@
 A one-page guide to **running the digital activity**. (First-time setup is in [`SETUP.md`](./SETUP.md);
 the in-session phase/time cues live on the participant page itself.)
 
-**Links** — replace `ROOM` with a code for this cohort (e.g. `june-am`):
+**Pages:**
 
-- Participant: `https://coolmukky.github.io/github-slideshow/zero-trust-design-sprint.html?room=ROOM`
-- Proctor:     `https://coolmukky.github.io/github-slideshow/proctor.html?room=ROOM`
-
-> Tip: generate a QR code for the participant link so people can join from their phones.
+- Proctor console: `https://coolmukky.github.io/github-slideshow/proctor.html`
+- Participant page: `https://coolmukky.github.io/github-slideshow/zero-trust-design-sprint.html`
+- Leaderboard: `https://coolmukky.github.io/github-slideshow/leaderboard.html`
 
 ---
 
-## Before the session (5 min)
+## Before the session — create the event (2 min)
 
-- [ ] Pages published and Firebase live (see `SETUP.md`; proctor should read **"Live · Firebase"**).
-- [ ] Pick a **room code** and build both links above with `?room=ROOM`.
-- [ ] Open the **proctor** link on your screen; confirm status is **"Live · Firebase"**.
-- [ ] Share the **participant** link / QR with the room.
-- [ ] Decide team names in advance (or let each table choose one) so people group correctly.
+- [ ] Open **`proctor.html`**; confirm status reads **"Live · Firebase"**.
+- [ ] Fill in the **event name**, an optional **scheduled date/time**, and note the auto-generated **event code** (↻ to regenerate). Click **Create event**.
+- [ ] Share the **event code** (and/or the **join link** shown on the console) with participants — a QR of the join link works well on phones.
 
-## Logging everyone in (5 min)
+## Opening for teams to join
 
-- [ ] Participants who open the link **before you open registration** see a **"Waiting for the proctor…"** screen — that's expected.
-- [ ] On **`proctor.html`** press **Open for login**. Everyone's waiting screen clears and they're prompted to take their seat.
-- [ ] Each person clicks **Take your seat**: name, email, **team name**, role — then they sit in a **lobby** (clock at 00:00) until you start it.
-- [ ] Watch the proctor **Event control** readout fill in: **"N logged in · T teams · K/T complete (4 roles)."** Nudge teams to fill missing roles.
+- [ ] Participants who open the page early see a **"Waiting for the proctor…"** screen (or a countdown if you scheduled a time).
+- [ ] When ready, press **Start event** on the proctor. Participants can now take their seat.
+- [ ] Each participant enters the **event code**, then their **name, email, role**, and either:
+  - **Creates a team** (first person): names it and gets a **team code** to share, or
+  - **Joins a team**: enters the **team code** their first teammate shared.
+- [ ] A team is **4 people, one per role** (Conductor, Critic, Architect, Scribe). **Each team's own 60-minute clock starts automatically once all 4 roles are filled.**
+- [ ] Watch the console: **"N joined · T teams · K/T full (4 roles) · R running."** Team cards show each team's code and a live **⏱ time-left**.
 
-## Starting the clock
+## During the hour
 
-- [ ] When everyone's in, press **Start clock** on the proctor. This starts the **single 60-minute clock for all teams at once**; every participant's board begins Phase 0 together.
+- [ ] Each team runs on **its own clock**; boards, phases, and **injection reveals (24/38/50 min)** follow it, with automatic **5-min / 1-min** warnings. Participants' local Start/Pause is locked.
 - [ ] *(Optional)* Ask teams to press **Focus** to hide reference sections — cuts on-page reading ~in half.
-- [ ] Boards, phases, and **injection reveals (24/38/50 min)** run off the shared clock; participants get **5-min and 1-min** warnings automatically. Participants' local Start/Pause is **locked**.
-- [ ] Use **Pause / Resume** on the proctor to hold the whole room; **Reset** sends everyone back to the lobby at 00:00. Keep the proctor tab open to watch the roster throughout.
+- [ ] Need to give a team a fresh 60? On its card press **Reset clock**. Press **Reset** (event) to close the event; **Start event** to reopen.
 
 ## After the clock (10 min)
 

--- a/PRE-READ.md
+++ b/PRE-READ.md
@@ -38,8 +38,10 @@ So the topic isn't cold, these are the Zero Trust controls a strong design appli
 Don't worry about mastering these — the exercise is about applying and defending them as a team.
 
 ## To join (takes 30 seconds)
-1. Open the participant link your facilitator shares.
-2. Click **Take your seat** → enter your **name, email, team name**, and pick your **role**.
-3. That's it — the facilitator starts the clock.
+1. Open the participant link and enter the **event code** your facilitator shares.
+2. Enter your **name, email**, and pick your **role**, then:
+   - **First on your team?** Choose **Create a team**, name it, and you'll get a **team code** — share it with your 3 teammates.
+   - **Joining teammates?** Choose **Join a team** and enter that **team code**.
+3. Your team is **4 people, one per role**. Your **60-minute clock starts automatically once all four of you have joined** — no need to press anything.
 
 See you there. 🚀

--- a/SETUP.md
+++ b/SETUP.md
@@ -112,14 +112,16 @@ Troubleshooting:
 
 ## 4. Running a session
 
-- **Multiple rooms/cohorts:** add `?room=CODE` to *both* page URLs to scope a roster to one
-  session, e.g. `…/proctor.html?room=june-cohort` and `…/zero-trust-design-sprint.html?room=june-cohort`.
-- **Two-phase start:** on `proctor.html`, press **Open for login** — participants (who until then
-  see a "Waiting for the proctor…" screen) can now take their seats and sit in a **lobby** at
-  00:00. The proctor shows a readiness readout ("N logged in · T teams · K/T complete"). When
-  everyone's in, press **Start clock** to begin the **single 60-minute clock for all teams at
-  once**. **Pause/Resume** holds the room; **Reset** returns everyone to the lobby. *(If no proctor
-  opens an event, a participant page falls back to a local self-run timer.)*
+- **Create an event:** on `proctor.html`, enter an **event name**, an optional **scheduled start**,
+  and note the generated **event code**; click **Create event**. Share the code (or the join link
+  the console shows). The event code scopes everything (roster, teams, scores) — it's the `?room=`
+  value in the URLs.
+- **Start / join:** press **Start event** to open joining. Participants enter the **event code**,
+  then their details and role, and either **create a team** (get a **team code** to share) or
+  **join a team** (enter that team code). A team is **4 fixed roles** (Conductor, Critic, Architect,
+  Scribe); its own **60-minute clock starts automatically once all 4 roles are filled**.
+- **Proctor controls:** the console shows each team's live **time-left**; **Reset clock** on a team
+  card gives that team a fresh 60:00; **Reset** (event) closes it and **Start event** reopens.
 - **Reports:** on `proctor.html`, use **Export CSV** for raw data or **Report** for a printable
   (PDF-ready) participant summary with per-team completeness. Scales to ~300 participants.
 - **Scoring & leaderboard:** teams click **Submit for scoring** on the participant page (after

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -87,7 +87,7 @@
 (function(){
   "use strict";
   var $=function(s){return document.querySelector(s);};
-  var ROOM=(new URLSearchParams(location.search)).get("room")||"default";
+  var ROOM=(new URLSearchParams(location.search)).get("room"); ROOM = ROOM ? ROOM.trim().toUpperCase() : "DEFAULT";
   $("#footRoom").textContent=ROOM;
   var scores={}, solutions={};
   function esc(s){ return String(s==null?"":s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
@@ -106,7 +106,7 @@
     board.innerHTML=list.map(function(s,i){
       var rank=i+1;
       var head = MEDALS[rank] ? ('<div class="medal">'+MEDALS[rank]+'</div>') : ('<div class="rank">'+rank+'</div>');
-      var sol = solutions[tkey(s.teamName)];
+      var sol = solutions[s.teamCode||tkey(s.teamName)];
       var lateTag = (sol && sol.late) ? ' <span class="late">LATE +'+fmtClock(sol.overtimeSec||0)+'</span>' : '';
       var timeTag = (sol && sol.totalTimeSec!=null) ? '  ·  ⏱ '+fmtClock(sol.totalTimeSec) : '';
       return '<div class="row r'+rank+'">'+head+
@@ -129,8 +129,8 @@
       var live=adapter.mode==="firebase";
       $("#status").className="status "+(live?"live":"local");
       $("#statusText").textContent=live?"Live · Firebase":"Single-device (local)";
-      adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
-      adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[s.teamCode||tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[s.teamCode||tkey(s.teamName)]=s; }); render(); });
     });
   } else { $("#statusText").textContent="Leaderboard unavailable"; }
 })();

--- a/proctor.html
+++ b/proctor.html
@@ -76,6 +76,30 @@
   .tclock.low{color:var(--amber)}
   .tclock.up{color:var(--red)}
   @media (max-width:700px){ .ctl-status{max-width:70vw} }
+  /* event setup */
+  .setup{margin:14px 0 0;padding:16px 18px;background:var(--surface);border:1px solid var(--line);border-left:4px solid var(--cyan);border-radius:14px;box-shadow:var(--shadow)}
+  .setup[hidden]{display:none}
+  .setup-h{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:16px;margin-bottom:12px}
+  .setup-fields{display:grid;grid-template-columns:1.4fr 1fr .9fr;gap:12px;margin-bottom:14px}
+  .setup-fields label{display:flex;flex-direction:column;gap:4px}
+  .setup-fields span{font-family:"IBM Plex Mono",monospace;font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint)}
+  .setup-fields input{border:1px solid var(--line);border-radius:9px;padding:9px 11px;font-family:"IBM Plex Sans",sans-serif;font-size:14px;color:var(--ink);outline:none;width:100%}
+  .setup-fields input:focus{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.12)}
+  #evCode{font-family:"IBM Plex Mono",monospace;font-weight:700;letter-spacing:.16em;text-transform:uppercase;text-align:center}
+  .evcode-row{display:flex;gap:6px}.evcode-row input{flex:1}
+  @media (max-width:700px){ .setup-fields{grid-template-columns:1fr} }
+  .ctl-join{font-family:"IBM Plex Mono",monospace;font-size:12px;color:#AEC4DC;padding-left:14px;border-left:1px solid rgba(255,255,255,.14)}
+  .ctl-join b{color:#fff;letter-spacing:.14em}
+  .ctl-join a{color:#7FE2EF}
+  /* per-team clock chips on cards */
+  .clock-row{display:flex;align-items:center;gap:9px;padding:8px 16px;border-top:1px solid var(--line-soft);background:#FAFCFF;flex-wrap:wrap}
+  .tcode{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:700;letter-spacing:.1em;color:#fff;background:var(--cyan-deep);border-radius:5px;padding:2px 7px}
+  .tclock{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:600;color:var(--cyan-deep)}
+  .tclock.idle{color:var(--ink-faint);font-weight:400}
+  .tclock.low{color:var(--amber)}
+  .tclock.up{color:var(--red)}
+  .treset{margin-left:auto;font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:600;color:var(--ink-soft);background:#fff;border:1px solid var(--line);border-radius:7px;padding:4px 9px;cursor:pointer}
+  .treset:hover{border-color:var(--amber);color:var(--amber)}
 
   .bar .filter{display:inline-flex;align-items:center;gap:6px;font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--ink-soft)}
   .bar .filter input{border:1px solid var(--line);border-radius:8px;padding:6px 9px;font-family:"IBM Plex Sans",sans-serif;font-size:13px;width:190px;outline:none}
@@ -186,11 +210,24 @@
     <b>Single-device mode.</b> Firebase isn't configured, so this roster only shows people who joined <b>on this device/browser</b>. To see every participant's device live, fill in <code>firebase-config.js</code> (setup steps are in that file).
   </div>
 
-  <div class="control" id="control">
+  <!-- event setup (shown until an event exists) -->
+  <div class="setup" id="evSetup" hidden>
+    <div class="setup-h">Create your event</div>
+    <div class="setup-fields">
+      <label><span>Event name</span><input id="evName" type="text" placeholder="e.g. SE Design Clinic — July" maxlength="80"></label>
+      <label><span>Scheduled start (optional)</span><input id="evWhen" type="datetime-local"></label>
+      <label><span>Event code</span><span class="evcode-row"><input id="evCode" type="text" maxlength="8" autocomplete="off"><button class="btn" id="evRegen" type="button" title="Generate a new code">↻</button></span></label>
+    </div>
+    <button class="btn primary" id="evCreate">Create event</button>
+  </div>
+
+  <!-- live control (shown once an event exists) -->
+  <div class="control" id="control" hidden>
     <div class="ctl-clock"><span class="ctl-time" id="ctlTime">CLOSED</span></div>
-    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event not started</span><span class="ctl-status" id="ctlStatus">Press “Open for login” — players register, then you start the clock for everyone</span></div>
+    <div class="ctl-phase"><span class="ctl-pname" id="ctlPhase">Event</span><span class="ctl-status" id="ctlStatus"></span></div>
+    <div class="ctl-join" id="ctlJoin"></div>
     <div class="ctl-btns">
-      <button class="btn primary" id="ctlStart"><span id="ctlStartLabel">Open for login</span></button>
+      <button class="btn primary" id="ctlStart"><span id="ctlStartLabel">Start event</span></button>
       <button class="btn" id="ctlReset" hidden>Reset</button>
     </div>
   </div>
@@ -244,10 +281,11 @@
   var $ = function(s){ return document.querySelector(s); };
   var ROLE_COLORS = { conductor:"#E2891F", critic:"#DB4A4A", architect:"#0FA9BE", scribe:"#27A276", facilitator:"#7E8CA1" };
   var ROLE_ORDER = { conductor:0, critic:1, architect:2, scribe:3, facilitator:4 };
-  var ROOM = (new URLSearchParams(location.search)).get("room") || "default";
-  $("#roomInput").value = ROOM;
-  $("#footRoom").textContent = ROOM;
-  $("#btnLeaderboard").href = "leaderboard.html" + (ROOM!=="default" ? ("?room="+encodeURIComponent(ROOM)) : "");
+  var ROOM = (new URLSearchParams(location.search)).get("room"); if(ROOM) ROOM=ROOM.trim().toUpperCase();
+  // labels updated via updateRoomLabels() once defined; set initial values here
+  if($("#roomInput")) $("#roomInput").value = ROOM||"";
+  if($("#footRoom")) $("#footRoom").textContent = ROOM||"—";
+  if($("#btnLeaderboard")) $("#btnLeaderboard").href = "leaderboard.html" + (ROOM ? ("?room="+encodeURIComponent(ROOM)) : "");
   var latest = [];
   var solutions = {};   // teamKey -> solution doc
   var scores = {};      // teamKey -> score doc
@@ -272,9 +310,9 @@
   function groupBy(players){
     var groups={}, order=[];
     players.forEach(function(p){
+      var key = p.teamCode || tkey(p.teamName) || "(no team)";
       var tn=(p.teamName||"(no team)").trim()||"(no team)";
-      var key=tn.toLowerCase();
-      if(!groups[key]){ groups[key]={name:tn,members:[]}; order.push(key); }
+      if(!groups[key]){ groups[key]={name:tn,code:(p.teamCode||""),members:[]}; order.push(key); }
       groups[key].members.push(p);
     });
     order.sort(function(a,b){ return groups[a].name.localeCompare(groups[b].name); });
@@ -333,8 +371,17 @@
         '</div>';
       }).join("");
       var missHtml = missing.length ? '<div class="miss">Missing: <b>'+missing.join(", ")+'</b></div>' : '';
+      // team-code + per-team clock row
+      var tk = key; // group key is the team code (fallback lowercased name)
+      var code = g.code || "";
+      var tc = code ? teamClocks[code] : null;
+      var clockHtml, rem = (tc && tc.startedAt) ? Math.max(0, TOTAL-(Date.now()-tc.startedAt)/1000) : null;
+      if(rem==null){ clockHtml = '<span class="tclock idle">assembling · '+g.members.length+'/4 roles</span>'; }
+      else if(rem<=0){ clockHtml = '<span class="tclock up">⏱ time up</span>'; }
+      else { clockHtml = '<span class="tclock'+(rem<300?' low':'')+'" data-teamclock="'+esc(code)+'">⏱ '+fmtClock(rem)+' left</span>'; }
+      var clockRow = '<div class="clock-row">'+(code?'<span class="tcode">'+esc(code)+'</span>':'')+clockHtml+
+        (code&&tc&&tc.startedAt?'<button class="treset" data-treset="'+esc(code)+'">Reset clock</button>':'')+'</div>';
       // score / evaluate footer
-      var tk = key; // group key is the lowercased team name
       var sol = solutions[tk], sc = scores[tk];
       var footer;
       if(sc){
@@ -351,7 +398,7 @@
       } else {
         footer = '<div class="score-row muted">No solution submitted yet</div>';
       }
-      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+' member'+(g.members.length===1?"":"s")+'</span></div>'+rows+missHtml+footer+'</div>';
+      return '<div class="team '+(teamComplete?"complete":"incomplete")+'"><div class="team-h"><h3>'+esc(g.name)+'</h3><span class="cnt'+(teamComplete?' ok':'')+'">'+g.members.length+'/4</span></div>'+clockRow+rows+missHtml+footer+'</div>';
     }).join("");
     renderControl(); // refresh lobby readiness counts after roster rebuild
   }
@@ -483,7 +530,7 @@
     var i1=clampNum($("#emI1").value,MAX_INJ), i2=clampNum($("#emI2").value,MAX_INJ), i3=clampNum($("#emI3").value,MAX_INJ), sv=clampNum($("#emSol").value,MAX_SOL);
     var sol=solutions[evalKey];
     var teamName=(sol&&sol.teamName) || (scores[evalKey]&&scores[evalKey].teamName) || evalKey;
-    var doc={ id:ROOM+"__"+evalKey, room:ROOM, teamName:teamName, i1:i1,i2:i2,i3:i3, solution:sv, total:i1+i2+i3+sv, notes:($("#emNotes").value||"").trim(), evaluatedAt:Date.now() };
+    var doc={ id:ROOM+"__"+evalKey, room:ROOM, teamCode:(solutions[evalKey]&&solutions[evalKey].teamCode)||evalKey, teamName:teamName, i1:i1,i2:i2,i3:i3, solution:sv, total:i1+i2+i3+sv, notes:($("#emNotes").value||"").trim(), evaluatedAt:Date.now() };
     try{ adapterRef.write("scores", doc); }catch(e){}
     scores[evalKey]=doc; // optimistic
     closeEval(); render();
@@ -494,28 +541,31 @@
     if(btn) openEval(btn.getAttribute("data-eval"));
   });
 
-  // ---------- event control: open for login, then one global clock for everyone ----------
-  var TOTAL=3600, eventDoc=null, controlEl=$("#control"), armedOnce=false;
-  var PHASES=[{no:"PHASE 0",name:"Brief-In",end:8,color:"#E2891F"},{no:"PHASE 1",name:"Expose",end:20,color:"#DB4A4A"},{no:"PHASE 2",name:"Decide",end:33,color:"#0FA9BE"},{no:"PHASE 3",name:"Design",end:48,color:"#2a6fb0"},{no:"PHASE 4",name:"Document",end:56,color:"#27A276"},{no:"PHASE 5",name:"Submit",end:60,color:"#122A47"}];
+  // ---------- event control: create/open the event; teams run their own clocks ----------
+  var TOTAL=3600, eventDoc=null, teamClocks={}, controlEl=$("#control"), setupEl=$("#evSetup"), adapterReady=false;
   function fmtClock(s){ s=Math.max(0,Math.round(s)); var m=Math.floor(s/60),ss=s%60; return (m<10?"0":"")+m+":"+(ss<10?"0":"")+ss; }
-  function evStat(){ return eventDoc ? (eventDoc.status||"closed") : "closed"; }
-  function evElapsed(){ var s=evStat(); if(s==="running") return Math.min(TOTAL,(eventDoc.baseElapsedSec||0)+(Date.now()-(eventDoc.startedAtMs||Date.now()))/1000); if(s==="paused") return Math.min(TOTAL,eventDoc.baseElapsedSec||0); return 0; }
-  function phaseAt(e){ if(e>=TOTAL) return null; for(var i=0;i<PHASES.length;i++){ if(e<PHASES[i].end*60) return PHASES[i]; } return PHASES[PHASES.length-1]; }
-  function readiness(){ var g=groupBy(latest); var complete=g.order.filter(function(k){ return isComplete(g.groups[k].members); }).length; return { players:latest.length, teams:g.order.length, complete:complete }; }
+  function randCode(n){ var A="ACDEFGHJKMNPQRTUVWXY34679", s=""; for(var i=0;i<(n||5);i++){ s+=A.charAt(Math.floor(Math.random()*A.length)); } return s; }
+  function evOpen(){ return !!(eventDoc && eventDoc.status==="open"); }
+  function joinLink(){ return location.href.split("?")[0].replace(/proctor\.html$/,"zero-trust-design-sprint.html") + "?room=" + encodeURIComponent(ROOM||""); }
+  function readiness(){ var g=groupBy(latest); var complete=g.order.filter(function(k){ return isComplete(g.groups[k].members); }).length; var started=0; Object.keys(teamClocks).forEach(function(c){ if(teamClocks[c].startedAt) started++; }); return { players:latest.length, teams:g.order.length, complete:complete, started:started }; }
   function renderControl(){
-    var s=evStat(), e=evElapsed(), ph=phaseAt(e), running=(s==="running"||s==="paused");
-    controlEl.classList.toggle("open", s!=="closed");
-    controlEl.style.setProperty("--pc", running?(e>=TOTAL?"#122A47":(ph?ph.color:"#0FA9BE")):"#0FA9BE");
-    var lbl=$("#ctlStartLabel"), sb=$("#ctlStart"), rb=$("#ctlReset");
-    if(s==="closed"){ $("#ctlTime").textContent="CLOSED"; lbl.textContent="Open for login"; sb.className="btn primary"; rb.hidden=true;
-      $("#ctlPhase").textContent="Event not started"; $("#ctlStatus").textContent="Press “Open for login” — players register, then you start the clock for everyone"; }
-    else if(s==="login"){ var r=readiness(); $("#ctlTime").textContent="LOBBY"; lbl.textContent="Start clock"; sb.className="btn primary"; rb.hidden=false; rb.textContent="Close";
-      $("#ctlPhase").textContent="Registration open — lobby"; $("#ctlStatus").textContent=r.players+" logged in · "+r.teams+" teams · "+r.complete+"/"+r.teams+" complete (4 roles) — press “Start clock” when ready"; }
-    else { // running or paused
-      $("#ctlTime").textContent=fmtClock(e); lbl.textContent = s==="running"?"Pause":"Resume"; sb.className = s==="running"?"btn warn":"btn primary"; rb.hidden=false; rb.textContent="Reset";
-      if(e>=TOTAL){ $("#ctlPhase").textContent="Time — hands off"; $("#ctlStatus").textContent="60 minutes elapsed"; }
-      else { $("#ctlPhase").textContent=ph.no+" · "+ph.name; $("#ctlStatus").textContent=(s==="paused"?"Paused · ":"Running · ")+fmtClock(ph.end*60-e)+" left in phase"; }
-    }
+    if(!eventDoc){ setupEl.hidden=false; controlEl.hidden=true; return; }
+    setupEl.hidden=true; controlEl.hidden=false;
+    var open=evOpen(); controlEl.classList.toggle("open", open);
+    controlEl.style.setProperty("--pc", open?"#0FA9BE":"#7E8CA1");
+    $("#ctlTime").textContent = open ? "OPEN" : "CLOSED";
+    $("#ctlPhase").textContent = eventDoc.name || ("Event "+ROOM);
+    $("#ctlStartLabel").textContent = open ? "Close event" : "Start event";
+    $("#ctlStart").className = open ? "btn warn" : "btn primary";
+    $("#ctlReset").hidden = !open; $("#ctlReset").textContent="Reset";
+    $("#ctlJoin").innerHTML = "code <b>"+esc(ROOM||"")+"</b> · <a href='"+joinLink()+"' target='_blank'>join link ↗</a>";
+    var r=readiness(), sched = eventDoc.scheduledAt ? (" · scheduled "+new Date(eventDoc.scheduledAt).toLocaleString()) : "";
+    $("#ctlStatus").textContent = open
+      ? (r.players+" joined · "+r.teams+" teams · "+r.complete+"/"+r.teams+" full (4 roles) · "+r.started+" running")
+      : ("Closed"+sched+" — press “Start event” to let players join with the code");
+    var spans=document.querySelectorAll("[data-teamclock]");
+    for(var i=0;i<spans.length;i++){ var el=spans[i], c=el.getAttribute("data-teamclock"), t=teamClocks[c];
+      if(t&&t.startedAt){ var rem=Math.max(0,TOTAL-(Date.now()-t.startedAt)/1000); el.textContent="⏱ "+fmtClock(rem)+" left"; el.className="tclock"+(rem<300&&rem>0?" low":"")+(rem<=0?" up":""); } }
   }
   function writeEvent(patch){
     if(!adapterRef){ alert("Not connected yet — try again in a moment."); return; }
@@ -524,39 +574,58 @@
     eventDoc=doc; try{ adapterRef.write("control", doc); }catch(e){} renderControl();
   }
   $("#ctlStart").addEventListener("click", function(){
-    var s=evStat(), now=Date.now();
-    if(s==="closed"){ if(!confirm("Open registration now? Players can take their seats; the clock stays at 00:00 until you start it.")) return; writeEvent({status:"login", openedAt:now}); }
-    else if(s==="login"){ var r=readiness(); if(!confirm("Start the 60-minute clock now for ALL "+r.players+" players / "+r.teams+" teams?\n\n"+r.complete+" of "+r.teams+" teams have all 4 roles.")) return; writeEvent({status:"running", runId:now, startedAtMs:now, baseElapsedSec:0}); }
-    else if(s==="running"){ var base=(eventDoc.baseElapsedSec||0)+(now-(eventDoc.startedAtMs||now))/1000; writeEvent({status:"paused", baseElapsedSec:base}); }
-    else { writeEvent({status:"running", startedAtMs:now}); }
+    if(!evOpen()){ if(!confirm("Start (open) the event now?\n\nPlayers can join with the code and form teams; each team's clock starts when its 4 roles are filled.")) return; writeEvent({status:"open", openedAt:Date.now()}); }
+    else { if(!confirm("Close the event?\n\nNew players can't join; teams already running keep their clocks.")) return; writeEvent({status:"closed"}); }
   });
-  $("#ctlReset").addEventListener("click", function(){
-    var s=evStat();
-    if(s==="login"){ if(!confirm("Close the event back to the waiting screen? Players will wait again.")) return; writeEvent({status:"closed"}); }
-    else { if(!confirm("Reset the clock to 00:00 and send everyone back to the lobby?")) return; writeEvent({status:"login", runId:0, startedAtMs:0, baseElapsedSec:0}); }
-  });
-  setInterval(renderControl,250); renderControl();
+  $("#ctlReset").addEventListener("click", function(){ if(!confirm("Reset the event back to closed? Players return to the waiting screen. (Team clocks are not cleared.)")) return; writeEvent({status:"closed"}); });
 
-  render();
-  if(window.ZTDSRoster){
+  // per-team clock reset (restart that team's 60:00)
+  $("#teams").addEventListener("click", function(e){
+    var t=e.target.closest ? e.target.closest("[data-treset]") : null;
+    if(!t) return;
+    var c=t.getAttribute("data-treset"), td=teamClocks[c]; if(!td) return;
+    if(!confirm("Restart the 60-minute clock for this team?")) return;
+    var doc=Object.assign({},td,{startedAt:Date.now()}); teamClocks[c]=doc;
+    try{ if(adapterRef) adapterRef.write("control",doc); }catch(e2){} render();
+  });
+  setInterval(renderControl,250);
+
+  // ---------- event setup (create) ----------
+  $("#evCode").value = ROOM || randCode(5);
+  $("#evRegen").addEventListener("click", function(){ $("#evCode").value=randCode(5); });
+  $("#evCreate").addEventListener("click", function(){
+    var name=($("#evName").value||"").trim(); if(!name){ $("#evName").focus(); alert("Give your event a name."); return; }
+    var code=($("#evCode").value||"").trim().toUpperCase(); if(!code){ code=randCode(5); }
+    var whenVal=$("#evWhen").value, sched=0; if(whenVal){ var d=new Date(whenVal); if(!isNaN(d.getTime())) sched=d.getTime(); }
+    ROOM=code; updateRoomLabels();
+    try{ history.replaceState(null,"","?room="+encodeURIComponent(ROOM)); }catch(e){}
+    startRoster(function(){ writeEvent({ name:name, scheduledAt:sched, status:"closed" }); });
+  });
+
+  function updateRoomLabels(){ if($("#roomInput")) $("#roomInput").value=ROOM||""; if($("#footRoom")) $("#footRoom").textContent=ROOM||"—"; if($("#btnLeaderboard")) $("#btnLeaderboard").href="leaderboard.html"+(ROOM?("?room="+encodeURIComponent(ROOM)):""); }
+
+  function startRoster(after){
+    if(!window.ZTDSRoster || !ROOM){ $("#statusText").textContent="Roster unavailable"; if(after) after(); return; }
     window.ZTDSRoster.init(ROOM).then(function(adapter){
-      adapterRef = adapter;
-      var live = adapter.mode==="firebase";
-      $("#status").className = "status "+(live?"live":"local");
-      $("#statusText").textContent = live ? "Live · Firebase" : "Single-device (local)";
-      $("#localNotice").hidden = live;
+      adapterRef=adapter; adapterReady=true;
+      var live=adapter.mode==="firebase";
+      $("#status").className="status "+(live?"live":"local");
+      $("#statusText").textContent=live?"Live · Firebase":"Single-device (local)";
+      $("#localNotice").hidden=live;
       adapter.watch("players", ROOM, function(d){ latest=d||[]; render(); });
-      adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[tkey(s.teamName)]=s; }); render(); });
-      adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("solutions", ROOM, function(d){ solutions={}; (d||[]).forEach(function(s){ solutions[s.teamCode||tkey(s.teamName)]=s; }); render(); });
+      adapter.watch("scores", ROOM, function(d){ scores={}; (d||[]).forEach(function(s){ scores[s.teamCode||tkey(s.teamName)]=s; }); render(); });
       adapter.watch("control", ROOM, function(d){
         var docs=d||[]; eventDoc=docs.filter(function(x){ return x.id===ROOM; })[0]||null;
-        if(!eventDoc && !armedOnce){ armedOnce=true; writeEvent({status:"closed"}); } // arm the room so participants wait
-        renderControl();
+        teamClocks={}; docs.forEach(function(x){ if(x.kind==="team" && x.teamCode) teamClocks[x.teamCode]=x; });
+        renderControl(); render();
       });
+      if(after) after();
     });
-  } else {
-    $("#statusText").textContent = "Roster unavailable";
   }
+
+  render(); renderControl();
+  if(ROOM){ startRoster(); } else { setupEl.hidden=false; controlEl.hidden=true; }
 })();
 </script>
 </body>

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -571,6 +571,15 @@
   .pm-field input.bad{border-color:var(--red);box-shadow:0 0 0 3px rgba(219,74,74,.12)}
   .pm-error{font-size:12.5px;color:var(--red);background:var(--red-soft);border:1px solid #F0C4C4;border-radius:9px;padding:8px 11px;margin:4px 0 2px}
   .pm-error[hidden]{display:none}
+  .pm-teammode{display:flex;gap:8px;margin:12px 0 8px}
+  .pm-tab{flex:1;border:1px solid var(--line);background:#fff;border-radius:10px;padding:9px 12px;font-family:"IBM Plex Sans",sans-serif;font-size:13.5px;font-weight:600;color:var(--ink-soft);cursor:pointer}
+  .pm-tab.on{border-color:var(--cyan-deep);background:#EAF7F9;color:var(--cyan-deep);box-shadow:0 0 0 2px rgba(15,169,190,.12)}
+  .pm-teamsec{background:#F7F9FC;border:1px solid var(--line-soft);border-radius:10px;padding:11px 13px}
+  .pm-teamsec[hidden]{display:none}
+  .pm-hint{font-size:12.5px;color:var(--ink-soft);margin:0 0 9px}
+  .pm-hint b{color:var(--ink)}
+  #pmCode{text-transform:uppercase;letter-spacing:.14em;font-family:"IBM Plex Mono",monospace}
+  .teamcode-chip{font-family:"IBM Plex Mono",monospace;font-weight:700;letter-spacing:.14em;color:#fff;background:var(--cyan-deep);border-radius:6px;padding:2px 8px}
   .pm-rolelbl{font-family:"IBM Plex Mono",monospace;font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint);margin:14px 0 8px}
   .pm-roles{display:grid;grid-template-columns:1fr 1fr;gap:10px}
   .pm-foot{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;margin-top:14px}
@@ -609,6 +618,10 @@
   .wo-spin{width:42px;height:42px;border-radius:50%;border:4px solid rgba(255,255,255,.18);border-top-color:var(--cyan);margin:0 auto 14px;animation:wospin 1s linear infinite}
   @keyframes wospin{to{transform:rotate(360deg)}}
   @media (prefers-reduced-motion:reduce){.wo-spin{animation:none}}
+  .wo-count{font-family:"IBM Plex Mono",monospace;font-size:30px;font-weight:600;color:#fff;margin-top:6px;letter-spacing:.04em}
+  .wo-codeform{display:flex;gap:8px;justify-content:center;margin-top:16px;flex-wrap:wrap}
+  .wo-codeform input{border:1px solid rgba(255,255,255,.3);background:rgba(255,255,255,.08);color:#fff;border-radius:10px;padding:11px 14px;font-family:"IBM Plex Mono",monospace;font-size:16px;letter-spacing:.18em;text-transform:uppercase;text-align:center;width:180px;outline:none}
+  .wo-codeform input::placeholder{color:#7E93AE;letter-spacing:.12em}
 
   /* --- focus / play view (hide reference sections during the hour) --- */
   body.focus-mode .ref-sec{display:none}
@@ -658,10 +671,15 @@
 <!-- ============ WAITING-FOR-PROCTOR OVERLAY (interactive) ============ -->
 <div class="wait-overlay" id="waitOverlay" hidden>
   <div class="wo-card">
-    <div class="wo-spin" aria-hidden="true"></div>
-    <div class="pm-eyebrow">Event not started</div>
-    <h2>Waiting for the proctor…</h2>
-    <p>The proctor hasn't opened registration yet. When they do, you'll be prompted to <b>take your seat</b> (name, email, team, role). Everyone logs in first — then the proctor starts the clock and all teams' 60 minutes begin together.</p>
+    <div class="wo-spin" id="woSpin" aria-hidden="true"></div>
+    <div class="pm-eyebrow" id="woEyebrow">Event</div>
+    <h2 id="woTitle">Waiting for the proctor…</h2>
+    <p id="woMsg">The proctor will open the event shortly.</p>
+    <div class="wo-count" id="woCountdown" hidden></div>
+    <form class="wo-codeform" id="woCodeForm" hidden>
+      <input id="woCode" type="text" placeholder="EVENT CODE" maxlength="8" autocomplete="off">
+      <button type="submit" class="fb-btn primary">Join event</button>
+    </form>
   </div>
 </div>
 
@@ -669,20 +687,33 @@
 <div class="persona-modal" id="personaModal" hidden role="dialog" aria-modal="true" aria-labelledby="pmTitle">
   <div class="pm-card">
     <button class="pm-close" id="pmClose" aria-label="Close">&times;</button>
-    <div class="pm-eyebrow">Join the sprint</div>
+    <div class="pm-eyebrow" id="pmEvent">Join the sprint</div>
     <h2 id="pmTitle">Take your seat</h2>
-    <p class="pm-sub">Enter your details, your <b>team name</b>, and the role you're playing. Your view highlights what <b>you</b> do in every phase — and your team appears live on the proctor's roster. Switch any time from the bar at the top.</p>
+    <p class="pm-sub">Enter your details and your role. <b>First on your team?</b> Create the team and share the code. <b>Joining teammates?</b> Enter their team code — your clock starts when everyone's in.</p>
     <div class="pm-fields">
       <label class="pm-field"><span>Your name</span><input id="pmName" type="text" placeholder="e.g. Sam Rivera" maxlength="60" autocomplete="name"></label>
       <label class="pm-field"><span>Email</span><input id="pmEmail" type="email" placeholder="you@company.com" maxlength="120" autocomplete="email"></label>
-      <label class="pm-field pm-wide"><span>Team name</span><input id="pmTeam" type="text" placeholder="e.g. Blue Team" maxlength="60" autocomplete="off"></label>
+    </div>
+    <div class="pm-teammode">
+      <button type="button" class="pm-tab on" id="pmTabCreate">➕ Create a team</button>
+      <button type="button" class="pm-tab" id="pmTabJoin">🔑 Join a team</button>
+    </div>
+    <div class="pm-teamsec" id="pmCreateSec">
+      <p class="pm-hint">You're the <b>first on your team</b>. Name it — you'll get a <b>team code</b> to share with your 3 teammates. A team is <b>4 people, one per role</b> (Conductor, Critic, Architect, Scribe); your clock starts once all 4 roles are filled.</p>
+      <div class="pm-fields">
+        <label class="pm-field pm-wide"><span>Team name</span><input id="pmTeam" type="text" placeholder="e.g. Blue Team" maxlength="60" autocomplete="off"></label>
+      </div>
+    </div>
+    <div class="pm-teamsec" id="pmJoinSec" hidden>
+      <p class="pm-hint">Enter the <b>team code</b> your first teammate shared with you (from when they created the team).</p>
+      <label class="pm-field pm-wide"><span>Team code</span><input id="pmCode" type="text" placeholder="e.g. 4F7Q" maxlength="8" autocomplete="off" style="text-transform:uppercase"></label>
     </div>
     <div class="pm-error" id="pmError" hidden></div>
-    <div class="pm-rolelbl">Pick your role</div>
+    <div class="pm-rolelbl">Pick your role (this submits)</div>
     <div class="pm-roles" id="pmRoles"></div>
     <div class="pm-foot">
       <button class="pm-skip" id="pmSkip">I'm just watching — skip for now</button>
-      <a class="pm-proctor" id="pmProctorLink" href="proctor.html">Proctor? Open the live roster &rarr;</a>
+      <a class="pm-proctor" id="pmProctorLink" href="proctor.html">Proctor? Open the console &rarr;</a>
     </div>
   </div>
 </div>
@@ -1842,65 +1873,63 @@
     if(elapsed>=TOTAL-300) fired["nudge5"]=true; if(elapsed>=TOTAL-60) fired["nudge1"]=true;
   }
   function primeFiredUpTo(e){ fired={}; CUES.forEach(function(c,i){ if(e>=c.sec) fired["cue"+i]=true; }); INJ.forEach(function(j,i){ if(e>=j.sec) fired["inj"+i]=true; }); if(e>=TOTAL-300) fired["nudge5"]=true; if(e>=TOTAL-60) fired["nudge1"]=true; }
-  // ---------- proctor-run event: login phase, then one global clock ----------
-  // Control doc (id=ROOM) status: "closed" (armed, waiting) -> "login" (registration open,
-  // no clock yet) -> "running" (global 60-min clock from startedAtMs) -> "paused".
-  // While an event exists (managed), the participant's local timer buttons are locked.
-  var managed=false, evStatus="closed", startedAtMs=0, baseElapsedSec=0, primedForRun=null, evTicker=null, lastControlDocs=[], eventDoc=null;
-  function evElapsed(){
-    if(evStatus==="running") return Math.min(TOTAL, (baseElapsedSec||0)+(Date.now()-(startedAtMs||Date.now()))/1000);
-    if(evStatus==="paused") return Math.min(TOTAL, baseElapsedSec||0);
-    return 0; // closed / login
-  }
-  function overtimeSec(){
-    if(managed && (evStatus==="running"||evStatus==="paused")){
-      var t=(evStatus==="running") ? (baseElapsedSec+(Date.now()-startedAtMs)/1000) : baseElapsedSec;
-      return Math.max(0, Math.round(t-TOTAL));
-    }
-    return 0;
-  }
+  // ---------- event + per-team-code clock ----------
+  // Event control doc (id=ROOM): {name, scheduledAt, status:"closed"|"open"}. Proctor opens it.
+  // Team control doc (id=ROOM__<teamCode>): {teamCode, teamName, size, startedAt}. The first
+  // member creates it (and shares the code); teammates join with the code; the team's 60-min
+  // clock auto-starts once `size` members have joined. Proctor can restart a team's clock.
+  var managed=false, eventOpen=false, eventName="", scheduledAt=0, teamStartedAt=null,
+      evTicker=null, lastControlDocs=[], eventDoc=null, allPlayers=[];
+  var CORE_ROLES=["conductor","critic","architect","scribe"];
+  function myCode(){ return persona && persona.teamCode ? persona.teamCode : null; }
+  function teamDocFor(code){ return code ? (lastControlDocs.filter(function(x){ return x.id===ROOM+"__"+code; })[0]||null) : null; }
+  function teamCount(code){ var n=0; allPlayers.forEach(function(p){ if(p.teamCode===code) n++; }); return n; }
+  function teamRoles(code){ var s={}; allPlayers.forEach(function(p){ if(p.teamCode===code && p.roleKey) s[p.roleKey]=true; }); return s; }
+  function teamMissingRoles(code){ var s=teamRoles(code); return CORE_ROLES.filter(function(r){ return !s[r]; }); }
+  function teamRolesComplete(code){ return teamMissingRoles(code).length===0; }
+  function evElapsed(){ if(managed && eventOpen && teamStartedAt) return Math.min(TOTAL,(Date.now()-teamStartedAt)/1000); return 0; }
+  function overtimeSec(){ if(managed && eventOpen && teamStartedAt) return Math.max(0,Math.round((Date.now()-teamStartedAt)/1000 - TOTAL)); return 0; }
   function updateManagedUI(){
-    var b=$("#btnStart"), lbl=$("#btnStartLabel"), sk=$("#btnSkip"), rs=$("#btnReset"), ov=$("#waitOverlay");
-    if(managed){
+    var b=$("#btnStart"), lbl=$("#btnStartLabel"), sk=$("#btnSkip"), rs=$("#btnReset");
+    if(ROOM){
       b.disabled=true; sk.disabled=true; rs.disabled=true;
-      b.title=sk.title=rs.title="The proctor runs the clock for this event";
-      lbl.textContent = evStatus==="running"?"Live":(evStatus==="paused"?"Paused":(evStatus==="login"?"Lobby":"Waiting"));
-      if(ov) ov.hidden = (evStatus!=="closed");   // full waiting overlay only before registration opens
-    } else {
-      b.disabled=false; sk.disabled=false; rs.disabled=false;
-      if(ov) ov.hidden = true;
+      b.title=sk.title=rs.title="Runs on your team's clock in this event";
+      lbl.textContent = !eventOpen ? "Waiting" : (teamStartedAt ? (evElapsed()<TOTAL?"Live":"Done") : "Lobby");
+    } else { b.disabled=false; sk.disabled=false; rs.disabled=false; }
+  }
+  function reconcileTeamStart(){
+    var td=teamDocFor(myCode());
+    if(managed && eventOpen && td && !td.startedAt && myCode() && teamRolesComplete(myCode())){
+      var doc=Object.assign({}, td, { startedAt:Date.now() });          // all 4 roles filled -> start clock
+      try{ if(roster) roster.write("control", doc); }catch(e){}
+      for(var i=0;i<lastControlDocs.length;i++){ if(lastControlDocs[i].id===doc.id){ lastControlDocs[i]=doc; break; } }
+      td=doc;
     }
+    var started = td ? (td.startedAt||null) : null;
+    if(started && started!==teamStartedAt){
+      teamStartedAt=started;
+      var e=Math.min(TOTAL,(Date.now()-teamStartedAt)/1000);
+      primeFiredUpTo(e); INJ.forEach(function(j){ j.manual=false; });
+      if(e<3){ toastWrap.innerHTML=""; toast("Your team clock started","Everyone's in — 60 minutes begin now, Phase 0 · Brief-In.","phase","00:00"); }
+    } else if(!started){ teamStartedAt=null; }
   }
-  function managedTick(){
-    elapsed=evElapsed(); running=(evStatus==="running" && elapsed<TOTAL);
-    render(); checkEvents(); updateManagedUI();
-  }
+  function managedTick(){ reconcileTeamStart(); elapsed=evElapsed(); running=(managed&&eventOpen&&!!teamStartedAt&&elapsed<TOTAL); render(); checkEvents(); updateManagedUI(); renderWait(); }
   function applyControlDocs(docs){
     lastControlDocs = docs || [];
     eventDoc = lastControlDocs.filter(function(x){ return x.id===ROOM; })[0] || null;
-    managed = !!eventDoc;
-    var prev = evStatus;
-    evStatus = eventDoc ? (eventDoc.status||"closed") : "closed";
-    startedAtMs = eventDoc ? (eventDoc.startedAtMs||0) : 0;
-    baseElapsedSec = eventDoc ? (eventDoc.baseElapsedSec||0) : 0;
-    if(managed){
-      if(ticker){ clearInterval(ticker); ticker=null; } // local timer yields to the event
+    managed = !!eventDoc; var prevOpen=eventOpen;
+    eventOpen = !!(eventDoc && eventDoc.status==="open");
+    eventName = eventDoc ? (eventDoc.name||"") : ""; scheduledAt = eventDoc ? (eventDoc.scheduledAt||0) : 0;
+    if(ROOM){
+      if(ticker){ clearInterval(ticker); ticker=null; }
       if(!evTicker) evTicker=setInterval(managedTick, 250);
-      if(evStatus==="login" && prev==="closed"){ toast("Registration open","The proctor opened the event — take your seat. The clock starts once everyone's in.","phase"); }
-      if(evStatus==="login" && (!persona || !persona.role)) openPersona();
-      if(evStatus==="running"){
-        if(primedForRun !== eventDoc.runId){
-          var e=evElapsed(); primeFiredUpTo(e); INJ.forEach(function(j){ j.manual=false; });
-          if(e<3){ toastWrap.innerHTML=""; toast("Clock started","The proctor started the 60 minutes — Phase 0 · Brief-In begins now.","phase","00:00"); }
-          primedForRun = eventDoc.runId;
-        }
-      } else if((evStatus==="login"||evStatus==="closed") && (prev==="running"||prev==="paused")){
-        fired={}; INJ.forEach(function(j){ j.manual=false; }); toastWrap.innerHTML=""; primedForRun=null; // clock reset back to lobby
-      }
+      if(eventOpen && !prevOpen){ toast("Event started","“"+(eventName||"The event")+"” is open — take your seat.","phase"); if(!persona||!persona.role) openPersona(); }
     }
-    elapsed=evElapsed(); running=(evStatus==="running" && elapsed<TOTAL);
-    updateManagedUI(); render(); checkEvents();
+    reconcileTeamStart();
+    elapsed=evElapsed(); running=(managed&&eventOpen&&!!teamStartedAt&&elapsed<TOTAL);
+    updateManagedUI(); render(); checkEvents(); renderWait();
   }
+  function onPlayers(d){ allPlayers=d||[]; reconcileTeamStart(); updateManagedUI(); renderWait(); }
 
   // ---------- audio chimes ----------
   function initAudio(){
@@ -1979,9 +2008,13 @@
     bar.style.setProperty("--pc", col);
 
     // bar phase text
-    if(managed && (evStatus==="login"||evStatus==="closed")){
-      $("#barPhase").textContent = evStatus==="login" ? "Lobby" : "Waiting";
-      $("#barNext").textContent = evStatus==="login" ? "Logged in — waiting for the proctor to start the clock" : "Waiting for the proctor to open registration";
+    if(ROOM && !eventOpen){
+      $("#barPhase").textContent="Waiting";
+      $("#barNext").textContent = (scheduledAt && Date.now()<scheduledAt) ? ("Starts "+new Date(scheduledAt).toLocaleTimeString()) : "Waiting for the proctor to open the event";
+    } else if(ROOM && eventOpen && !teamStartedAt){
+      var td=teamDocFor(myCode());
+      $("#barPhase").textContent="Lobby";
+      $("#barNext").textContent = td ? ("Team "+persona.teamCode+" · "+teamCount(myCode())+"/4 joined — missing "+(teamMissingRoles(myCode()).map(function(r){return ROLES[r].short;}).join(", ")||"nobody")+"") : "Take your seat to create or join a team";
     } else if(elapsed>=TOTAL){
       var ot=overtimeSec();
       $("#barPhase").textContent = ot>0 ? "Overtime" : "Time — hands off";
@@ -2215,7 +2248,7 @@
     function teamKey(t){ return (t||"").trim().toLowerCase(); }
     function refreshSubmitStatus(){
       if(!persona || !persona.team){ statusEl.textContent=""; subBtn.lastChild.textContent="Submit for scoring"; return; }
-      var raw=null; try{ raw=localStorage.getItem("ztds.submitInfo."+teamKey(persona.team)); }catch(e){}
+      var raw=null; try{ raw=localStorage.getItem("ztds.submitInfo."+(persona.teamCode||teamKey(persona.team))); }catch(e){}
       if(raw){ var s; try{ s=JSON.parse(raw); }catch(e){ s=null; }
         if(s){ statusEl.textContent="Submitted "+new Date(s.at).toLocaleTimeString()+(s.late?(" · LATE +"+fmt(s.overtimeSec)):"")+" · took "+fmt(s.totalTimeSec); statusEl.style.color=s.late?"var(--red)":"var(--green)"; }
         subBtn.lastChild.textContent="Re-submit for scoring";
@@ -2226,13 +2259,11 @@
         toast("Take your seat first","Click “Take your seat” (top bar) and enter your team name before submitting for scoring.","fire"); return;
       }
       if(!roster){ toast("Not connected yet","The scoring sync isn't ready — wait a moment and try again.","fire"); return; }
-      var tk=teamKey(persona.team), when=Date.now();
-      // timing: total time on the clock (uncapped), overtime past 60:00, late flag
-      var total;
-      if(managed && (evStatus==="running"||evStatus==="paused")){ total = (baseElapsedSec||0) + (evStatus==="running" ? (when-startedAtMs)/1000 : 0); }
-      else { total = elapsed; }
+      var tk=(persona.teamCode||teamKey(persona.team)), when=Date.now();
+      // timing: total time on the team clock (uncapped), overtime past 60:00, late flag
+      var total = teamStartedAt ? (when-teamStartedAt)/1000 : elapsed;
       total=Math.max(0,Math.round(total)); var over=Math.max(0,total-TOTAL), late=total>TOTAL;
-      var doc={ id:ROOM+"__"+tk, room:ROOM, teamName:persona.team, submittedByName:persona.name||"", submittedAt:when,
+      var doc={ id:ROOM+"__"+tk, room:ROOM, teamCode:persona.teamCode||"", teamName:persona.team, submittedByName:persona.name||"", submittedAt:when,
                 totalTimeSec:total, overtimeSec:over, late:late, diagram: diagramDataUrl||"",
                 fields: inputs.map(function(x){ return { label:x.label, value:x.ta.value.trim() }; }) };
       try{ roster.write("solutions", doc); }catch(e){}
@@ -2253,25 +2284,62 @@
     facilitator:{label:"Facilitator / Observer", short:"Facilitator", color:"#7E8CA1", chip:null, col:0, card:null, tag:"Runs the session — not an in-game seat"}
   };
   var personaModal=$("#personaModal"), personaLabel=$("#personaLabel"), pmRoles=$("#pmRoles");
-  var pmName=$("#pmName"), pmEmail=$("#pmEmail"), pmTeam=$("#pmTeam"), pmError=$("#pmError");
+  var pmName=$("#pmName"), pmEmail=$("#pmEmail"), pmTeam=$("#pmTeam"), pmSize=$("#pmSize"), pmCode=$("#pmCode"), pmError=$("#pmError");
+  var teamMode="create";
+  function setTeamMode(m){ teamMode=m; $("#pmTabCreate").classList.toggle("on",m==="create"); $("#pmTabJoin").classList.toggle("on",m==="join"); $("#pmCreateSec").hidden=(m!=="create"); $("#pmJoinSec").hidden=(m!=="join"); }
+  $("#pmTabCreate").addEventListener("click", function(){ setTeamMode("create"); });
+  $("#pmTabJoin").addEventListener("click", function(){ setTeamMode("join"); });
+  function randCode(n){ var A="ACDEFGHJKMNPQRTUVWXY34679", s=""; for(var i=0;i<(n||4);i++){ s+=A.charAt(Math.floor(Math.random()*A.length)); } return s; }
   var persona=null;
   try{ persona=JSON.parse(localStorage.getItem("ztds.persona")||"null"); }catch(e){}
   function esc(s){ return String(s).replace(/[&<>"]/g,function(c){ return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
 
   // shared cross-device roster (Firebase if configured, else single-device fallback)
-  var ROOM=(new URLSearchParams(location.search)).get("room") || "default";
+  var ROOM=(new URLSearchParams(location.search)).get("room");            // the EVENT CODE; null until joined
+  if(ROOM){ ROOM = ROOM.trim().toUpperCase(); }
   var roster=null, playerId=null;
   try{ playerId=localStorage.getItem("ztds.playerId"); }catch(e){}
   if(!playerId){ playerId="p-"+Math.random().toString(36).slice(2,10)+Date.now().toString(36); try{ localStorage.setItem("ztds.playerId",playerId); }catch(e){} }
-  function rosterRecord(p){ var r=ROLES[p.role]||{}; return { id:playerId, room:ROOM, name:p.name||"", email:p.email||"", role:r.short||"", roleKey:p.role, teamName:p.team||"", joinedAt:p.joinedAt||Date.now() }; }
-  if(window.ZTDSRoster){
+  function rosterRecord(p){ var r=ROLES[p.role]||{}; return { id:playerId, room:ROOM, name:p.name||"", email:p.email||"", role:r.short||"", roleKey:p.role, teamName:p.team||"", teamCode:p.teamCode||"", joinedAt:p.joinedAt||Date.now() }; }
+  if(window.ZTDSRoster && ROOM){
     window.ZTDSRoster.init(ROOM).then(function(a){
       roster=a;
-      if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.team){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
+      if(persona && persona.role && persona.role!=="facilitator" && persona.email && persona.teamCode){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
       try{ roster.watch("control", ROOM, function(d){ applyControlDocs(d||[]); }); }catch(e){}
+      try{ roster.watch("players", ROOM, function(d){ onPlayers(d||[]); }); }catch(e){}
     });
   }
-  var pl=$("#pmProctorLink"); if(pl) pl.href="proctor.html"+(ROOM!=="default"?("?room="+encodeURIComponent(ROOM)):"");
+  var pl=$("#pmProctorLink"); if(pl) pl.href="proctor.html"+(ROOM?("?room="+encodeURIComponent(ROOM)):"");
+
+  // ---------- waiting / event-code / countdown overlay ----------
+  function fmtCountdown(ms){ ms=Math.max(0,ms); var s=Math.round(ms/1000), h=Math.floor(s/3600), m=Math.floor((s%3600)/60), ss=s%60; function p(n){return (n<10?"0":"")+n;} return (h>0?(h+":"):"")+p(m)+":"+p(ss); }
+  function renderWait(){
+    var ov=$("#waitOverlay"); if(!ov) return;
+    var form=$("#woCodeForm"), cd=$("#woCountdown"), spin=$("#woSpin");
+    if(!ROOM){
+      ov.hidden=false; form.hidden=false; cd.hidden=true; spin.style.display="none";
+      $("#woEyebrow").textContent="Join an event"; $("#woTitle").textContent="Enter your event code";
+      $("#woMsg").textContent="Your proctor shared an event code — type it in to join.";
+      return;
+    }
+    form.hidden=true; spin.style.display="";
+    if(!eventOpen){
+      ov.hidden=false; $("#woEyebrow").textContent=eventName||("Event "+ROOM);
+      if(scheduledAt && Date.now()<scheduledAt){
+        $("#woTitle").textContent="Starting soon"; cd.hidden=false; cd.textContent=fmtCountdown(scheduledAt-Date.now());
+        $("#woMsg").textContent="“"+(eventName||"The event")+"” is scheduled for "+new Date(scheduledAt).toLocaleString()+". The proctor opens it then.";
+      } else {
+        $("#woTitle").textContent="Waiting for the proctor…"; cd.hidden=true;
+        $("#woMsg").textContent = managed ? ("“"+(eventName||"The event")+"” — the proctor will open registration shortly. Then take your seat.") : ("Joined event "+ROOM+". Waiting for the proctor to create/open it…");
+      }
+      return;
+    }
+    ov.hidden=true;
+  }
+  $("#woCodeForm").addEventListener("submit", function(e){
+    e.preventDefault(); var v=($("#woCode").value||"").trim().toUpperCase();
+    if(v) location.search="?room="+encodeURIComponent(v);
+  });
 
   // build role buttons
   Object.keys(ROLES).forEach(function(key){
@@ -2331,34 +2399,55 @@
   function showPmError(m){ pmError.textContent=m; pmError.hidden=false; }
   function hidePmError(){ pmError.hidden=true; }
   function openPersona(){
+    var evEl=$("#pmEvent"); if(evEl) evEl.textContent = eventName ? ("Join · "+eventName) : "Join the sprint";
     pmName.value = persona&&persona.name ? persona.name : "";
     pmEmail.value = persona&&persona.email ? persona.email : "";
-    pmTeam.value = persona&&persona.team ? persona.team : "";
+    if(persona && persona.teamCode){ setTeamMode("join"); pmCode.value=persona.teamCode; pmTeam.value=persona.team||""; }
+    else setTeamMode("create");
     hidePmError();
-    [pmName,pmEmail,pmTeam].forEach(function(el){ el.classList.remove("bad"); });
+    [pmName,pmEmail,pmTeam,pmSize,pmCode].forEach(function(el){ if(el) el.classList.remove("bad"); });
     personaModal.hidden=false; setTimeout(function(){ pmName.focus(); },50);
   }
   function closePersona(){ personaModal.hidden=true; try{ localStorage.setItem("ztds.personaSeen","1"); }catch(e){} }
   function choosePersona(key){
-    var name=(pmName.value||"").trim(), email=(pmEmail.value||"").trim(), team=(pmTeam.value||"").trim();
+    var name=(pmName.value||"").trim(), email=(pmEmail.value||"").trim();
     var r=ROLES[key];
-    [pmName,pmEmail,pmTeam].forEach(function(el){ el.classList.remove("bad"); });
+    [pmName,pmEmail,pmTeam,pmSize,pmCode].forEach(function(el){ if(el) el.classList.remove("bad"); });
+    if(ROOM && !eventOpen && key!=="facilitator"){ showPmError("The event isn't open yet — wait for the “Event started” message, then take your seat."); return; }
+    var team="", teamCode="";
     if(key!=="facilitator"){
       var missing=[];
       if(!name){ pmName.classList.add("bad"); missing.push("your name"); }
       if(!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)){ pmEmail.classList.add("bad"); missing.push("a valid email"); }
-      if(!team){ pmTeam.classList.add("bad"); missing.push("a team name"); }
-      if(missing.length){ showPmError("Please enter "+missing.join(", ")+" to join a team — or choose Facilitator / Observer to skip."); return; }
+      if(missing.length){ showPmError("Please enter "+missing.join(", ")+" — or choose Facilitator / Observer to skip."); return; }
+      if(teamMode==="create"){
+        team=(pmTeam.value||"").trim();
+        if(!team){ pmTeam.classList.add("bad"); showPmError("Name your team (you're creating it)."); return; }
+        teamCode = randCode(4);
+        if(roster){ var nd={ id:ROOM+"__"+teamCode, room:ROOM, kind:"team", teamCode:teamCode, teamName:team, size:4, startedAt:null };
+          try{ roster.write("control", nd); }catch(e){} lastControlDocs.push(nd); }
+      } else { // join
+        teamCode=(pmCode.value||"").trim().toUpperCase();
+        if(!teamCode){ pmCode.classList.add("bad"); showPmError("Enter the team code your first teammate shared."); return; }
+        var td=teamDocFor(teamCode);
+        if(!td){ pmCode.classList.add("bad"); showPmError("No team found for code “"+esc(teamCode)+"”. Check with your teammate who created it."); return; }
+        team=td.teamName||("Team "+teamCode);
+      }
+      // one person per role on a team (4 fixed roles)
+      var taken=teamRoles(teamCode); var mineNow=allPlayers.filter(function(p){ return p.id===playerId; })[0];
+      if(taken[key] && !(mineNow && mineNow.teamCode===teamCode && mineNow.roleKey===key)){
+        showPmError((ROLES[key].short)+" is already taken on this team — pick one of the open roles: "+teamMissingRoles(teamCode).map(function(r){return ROLES[r].short;}).join(", ")+"."); return;
+      }
     }
-    if(managed && evStatus==="closed" && key!=="facilitator"){ showPmError("The proctor hasn't opened registration yet — please wait for the “Registration open” message, then take your seat."); return; }
     hidePmError();
-    persona={ role:key, name:name, email:email, team:team, joinedAt:Date.now() };
+    persona={ role:key, name:name, email:email, team:team, teamCode:teamCode, joinedAt:Date.now() };
     try{ localStorage.setItem("ztds.persona", JSON.stringify(persona)); }catch(e){}
     applyPersona(); closePersona();
     if(roster && key!=="facilitator"){ try{ roster.write("players", rosterRecord(persona)); }catch(e){} }
-    updateManagedUI();
-    if(managed && key!=="facilitator") toast("You're in the lobby", "Logged in as <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+". The clock starts when the proctor starts it.", "phase");
-    else toast("Seat taken", (name?esc(name)+", you":"You")+" are <b>"+r.label+"</b>"+(team?" on <b>"+esc(team)+"</b>":"")+".", "phase");
+    reconcileTeamStart(); updateManagedUI(); renderWait();
+    if(key==="facilitator"){ toast("Observer", "You're viewing as <b>Facilitator / Observer</b>.", "phase"); }
+    else if(teamMode==="create"){ toast("Team created", "Your team code is <span class='teamcode-chip'>"+esc(teamCode)+"</span> — share it with your 3 teammates. The clock starts once all 4 roles are filled.", "phase"); }
+    else { toast("Joined team", "You joined <b>"+esc(team)+"</b> (code "+esc(teamCode)+"). Waiting for the rest of the team…", "phase"); }
   }
   $("#btnPersona").addEventListener("click", openPersona);
   $("#pmClose").addEventListener("click", closePersona);
@@ -2393,9 +2482,8 @@
   render();
   applyPersona();
   applyFocus();
-  var seen=false; try{ seen=localStorage.getItem("ztds.personaSeen")==="1"; }catch(e){}
-  if(!persona && !seen) openPersona();
-  if(running){ lastTs=Date.now(); ticker=setInterval(tick,250); }
+  updateManagedUI(); renderWait();      // event-driven: show code entry / waiting until the proctor opens
+  if(!ROOM && running){ lastTs=Date.now(); ticker=setInterval(tick,250); } // local practice only when no event code
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary

Reworks joining and timing around **proctor-created events** and **team join codes**, with per-team clocks that auto-start when a team's 4 roles are filled.

## Proctor (`proctor.html`)
- **Create an event**: event name, optional **scheduled start**, and a generated **event code** (↻ to regenerate). The console shows the code + a **join link**.
- **Start event** opens joining; **Reset** closes it.
- Team cards show each team's **code** and a live **⏱ time-left**, plus **Reset clock** (fresh 60:00) per team. Status: joined / teams / full (4 roles) / running.

## Participant (`zero-trust-design-sprint.html`)
- Join by **event code** (entry screen when the URL has none; **countdown** if the event is scheduled).
- Taking a seat is **Create a team** (name → generated **team code** to share) or **Join a team** (enter that code). **One person per role** is enforced.
- A team is **4 fixed roles**; its own **60-minute clock auto-starts once all 4 roles are filled**. Before that, teammates wait in a lobby that shows which roles are still missing.

## Plumbing
- Roster / solutions / scores / clocks keyed by **team code**; leaderboard and submission timing follow the per-team clock.
- **No Firebase rules change** — event and team documents both live in the existing `control` collection.
- Docs updated: `FACILITATOR.md`, `SETUP.md`, `PRE-READ.md`.

## Testing
Multi-client browser test (local adapter): proctor creates + opens an event; one participant creates a team and gets a code; three join by code with distinct roles; the team clock **auto-starts on the 4th role**; the proctor sees the running clock and can **reset** it (verified 49:59 → 60:00); a no-code visitor gets the join screen. All pages load with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_