### PR TITLE
Add a scannable join QR on the proctor console

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -15,7 +15,7 @@ the in-session phase/time cues live on the participant page itself.)
 
 - [ ] Open **`proctor.html`**; confirm status reads **"Live · Firebase"**.
 - [ ] Fill in the **event name**, an optional **scheduled date/time**, and note the auto-generated **event code** (↻ to regenerate). Click **Create event**.
-- [ ] Share the **event code** (and/or the **join link** shown on the console) with participants — a QR of the join link works well on phones.
+- [ ] Share the **event code** with participants, or click **QR** on the console to show a scannable **join QR** (opens the participant page with the code pre-filled) — great for phones. The **join link** is there too.
 
 ## Opening for teams to join
 

--- a/proctor.html
+++ b/proctor.html
@@ -91,6 +91,8 @@
   .ctl-join{font-family:"IBM Plex Mono",monospace;font-size:12px;color:#AEC4DC;padding-left:14px;border-left:1px solid rgba(255,255,255,.14)}
   .ctl-join b{color:#fff;letter-spacing:.14em}
   .ctl-join a{color:#7FE2EF}
+  .linkbtn{font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;color:#0a1830;background:#7FE2EF;border:none;border-radius:6px;padding:3px 9px;cursor:pointer}
+  .linkbtn:hover{background:#a5ecf5}
   /* per-team clock chips on cards */
   .clock-row{display:flex;align-items:center;gap:9px;padding:8px 16px;border-top:1px solid var(--line-soft);background:#FAFCFF;flex-wrap:wrap}
   .tcode{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:700;letter-spacing:.1em;color:#fff;background:var(--cyan-deep);border-radius:5px;padding:2px 7px}
@@ -270,6 +272,19 @@
         </div>
       </div>
     </div>
+  </div>
+</div>
+
+<!-- QR modal -->
+<div class="eval-modal" id="qrModal" hidden role="dialog" aria-modal="true">
+  <div class="em-card" style="width:min(420px,100%);text-align:center">
+    <button class="em-close" id="qrClose" aria-label="Close">&times;</button>
+    <div class="em-eyebrow">Scan to join</div>
+    <h2 id="qrEvent" style="margin-bottom:12px">Event</h2>
+    <img id="qrImg" alt="Join QR code" style="width:260px;height:260px;max-width:100%;border-radius:12px;border:1px solid var(--line);background:#fff">
+    <div id="qrCode" style="font-family:'IBM Plex Mono',monospace;font-weight:700;font-size:22px;letter-spacing:.16em;margin-top:12px"></div>
+    <div style="font-family:'IBM Plex Mono',monospace;font-size:11.5px;color:var(--ink-faint);margin-top:6px;word-break:break-all"><a id="qrLink" href="#" target="_blank"></a></div>
+    <p style="font-size:12px;color:var(--ink-faint);margin-top:10px">Scanning opens the participant page with the code pre-filled. (QR image needs internet.)</p>
   </div>
 </div>
 
@@ -558,7 +573,7 @@
     $("#ctlStartLabel").textContent = open ? "Close event" : "Start event";
     $("#ctlStart").className = open ? "btn warn" : "btn primary";
     $("#ctlReset").hidden = !open; $("#ctlReset").textContent="Reset";
-    $("#ctlJoin").innerHTML = "code <b>"+esc(ROOM||"")+"</b> · <a href='"+joinLink()+"' target='_blank'>join link ↗</a>";
+    $("#ctlJoin").innerHTML = "code <b>"+esc(ROOM||"")+"</b> · <a href='"+joinLink()+"' target='_blank'>join link ↗</a> · <button class='linkbtn' id='ctlQr' type='button'>QR</button>";
     var r=readiness(), sched = eventDoc.scheduledAt ? (" · scheduled "+new Date(eventDoc.scheduledAt).toLocaleString()) : "";
     $("#ctlStatus").textContent = open
       ? (r.players+" joined · "+r.teams+" teams · "+r.complete+"/"+r.teams+" full (4 roles) · "+r.started+" running")
@@ -578,6 +593,22 @@
     else { if(!confirm("Close the event?\n\nNew players can't join; teams already running keep their clocks.")) return; writeEvent({status:"closed"}); }
   });
   $("#ctlReset").addEventListener("click", function(){ if(!confirm("Reset the event back to closed? Players return to the waiting screen. (Team clocks are not cleared.)")) return; writeEvent({status:"closed"}); });
+
+  // QR of the join link (delegated — #ctlJoin re-renders each tick)
+  var qrModal=$("#qrModal");
+  function openQr(){
+    var link=joinLink();
+    $("#qrEvent").textContent = (eventDoc&&eventDoc.name) || ("Event "+(ROOM||""));
+    $("#qrCode").textContent = ROOM||"";
+    var a=$("#qrLink"); a.textContent=link; a.href=link;
+    var img=$("#qrImg");
+    img.onerror=function(){ img.style.display="none"; };
+    img.style.display=""; img.src="https://api.qrserver.com/v1/create-qr-code/?size=260x260&margin=8&data="+encodeURIComponent(link);
+    qrModal.hidden=false;
+  }
+  $("#control").addEventListener("click", function(e){ if(e.target && e.target.id==="ctlQr") openQr(); });
+  $("#qrClose").addEventListener("click", function(){ qrModal.hidden=true; });
+  qrModal.addEventListener("click", function(e){ if(e.target===qrModal) qrModal.hidden=true; });
 
   // per-team clock reset (restart that team's 60:00)
   $("#teams").addEventListener("click", function(e){


### PR DESCRIPTION
## Summary

Adds a **QR** button next to the join link on the proctor console. It opens a modal with a scannable QR of the event's **join link** (the participant page with the event code pre-filled), plus the **code** and **link** as text.

- The QR image is fetched from a public QR service and **hides gracefully if offline** — the code and link stay visible as a fallback.
- Scanning takes a participant straight to the join page with `?room=CODE`, so they skip typing the code.
- `FACILITATOR.md` notes the button.

## Testing
Browser test: after creating + opening an event, the QR button appears; the modal opens showing the correct code (`QRC1`), a `?room=QRC1` join link, and a QR image URL encoding that link. No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_