### PR TITLE
Rename participant roles to job titles

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -24,7 +24,7 @@ the in-session phase/time cues live on the participant page itself.)
 - [ ] Each participant enters the **event code**, then their **name, email, role**, and either:
   - **Creates a team** (first person): names it and gets a **team code** to share, or
   - **Joins a team**: enters the **team code** their first teammate shared.
-- [ ] A team is **4 people, one per role** (Conductor, Critic, Architect, Scribe). **Each team's own 60-minute clock starts automatically once all 4 roles are filled.**
+- [ ] A team is **4 people, one per role** (IT Director, Digital Resiliency Officer, Network Architect, Network Security). **Each team's own 60-minute clock starts automatically once all 4 roles are filled.**
 - [ ] Watch the console: **"N joined · T teams · K/T full (4 roles) · R running."** Team cards show each team's code and a live **⏱ time-left**.
 
 ## During the hour

--- a/PRE-READ.md
+++ b/PRE-READ.md
@@ -14,10 +14,10 @@ Take a company drowning in over-privileged AI agents and redesign it so every ag
 own identity, only the access it needs, a checkpoint on every action, and a full audit trail.
 
 ## Pick a role (you'll choose at the start)
-- **Conductor** — owns the clock; keeps the team on pace.
-- **Critic** — challenges decisions: "what would make this fail?"
-- **Architect** — draws the topology diagram.
-- **Scribe** — writes the one-page solution sheet.
+- **IT Director** — owns the clock; keeps the team on pace.
+- **Digital Resiliency Officer** — challenges decisions: "what would make this fail?"
+- **Network Architect** — draws the topology diagram.
+- **Network Security** — writes the one-page solution sheet.
 
 *(Teams of 3 or 5 adapt — the facilitator will say how.)*
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -118,8 +118,8 @@ Troubleshooting:
   value in the URLs.
 - **Start / join:** press **Start event** to open joining. Participants enter the **event code**,
   then their details and role, and either **create a team** (get a **team code** to share) or
-  **join a team** (enter that team code). A team is **4 fixed roles** (Conductor, Critic, Architect,
-  Scribe); its own **60-minute clock starts automatically once all 4 roles are filled**.
+  **join a team** (enter that team code). A team is **4 fixed roles** (IT Director, Digital Resiliency Officer, Network Architect,
+  Network Security); its own **60-minute clock starts automatically once all 4 roles are filled**.
 - **Proctor controls:** the console shows each team's live **time-left**; **Reset clock** on a team
   card gives that team a fresh 60:00; **Reset** (event) closes it and **Start event** reopens.
 - **Reports:** on `proctor.html`, use **Export CSV** for raw data or **Report** for a printable

--- a/proctor.html
+++ b/proctor.html
@@ -319,7 +319,7 @@
   function fmtTime(ms){ if(!ms) return ""; var d=new Date(ms); var h=d.getHours(), m=d.getMinutes(); return (h<10?"0":"")+h+":"+(m<10?"0":"")+m; }
 
   var CORE_ROLES = ["conductor","critic","architect","scribe"];
-  var ROLE_LABELS = { conductor:"Conductor", critic:"Critic", architect:"Architect", scribe:"Scribe", facilitator:"Facilitator" };
+  var ROLE_LABELS = { conductor:"IT Director", critic:"Digital Resiliency Officer", architect:"Network Architect", scribe:"Network Security", facilitator:"Facilitator" };
   var filterText = "";
 
   function groupBy(players){

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -700,7 +700,7 @@
       <button type="button" class="pm-tab" id="pmTabJoin">🔑 Join a team</button>
     </div>
     <div class="pm-teamsec" id="pmCreateSec">
-      <p class="pm-hint">You're the <b>first on your team</b>. Name it — you'll get a <b>team code</b> to share with your 3 teammates. A team is <b>4 people, one per role</b> (Conductor, Critic, Architect, Scribe); your clock starts once all 4 roles are filled.</p>
+      <p class="pm-hint">You're the <b>first on your team</b>. Name it — you'll get a <b>team code</b> to share with your 3 teammates. A team is <b>4 people, one per role</b> (IT Director, Digital Resiliency Officer, Network Architect, Network Security); your clock starts once all 4 roles are filled.</p>
       <div class="pm-fields">
         <label class="pm-field pm-wide"><span>Team name</span><input id="pmTeam" type="text" placeholder="e.g. Blue Team" maxlength="60" autocomplete="off"></label>
       </div>
@@ -781,7 +781,7 @@
       <span class="sec-no">THE BOARD</span>
       <h2>Your 60-minute mission track</h2>
     </div>
-    <p class="sec-sub">Six phases, one hour. This track is the spine of the whole exercise — every phase below shows where you are on it. The Conductor moves the team from station to station and never lets a phase overrun. When the amber band fills, the round is locked.</p>
+    <p class="sec-sub">Six phases, one hour. This track is the spine of the whole exercise — every phase below shows where you are on it. The IT Director moves the team from station to station and never lets a phase overrun. When the amber band fills, the round is locked.</p>
     <div class="track-card">
       <span class="eyebrow">Move left → right · Times are hard stops</span>
       <div class="track-scroll">
@@ -910,7 +910,7 @@
       <div class="card">
         <div class="ic" style="background:var(--red)"><svg viewBox="0 0 24 24" fill="none" stroke="#fff"><path d="M12 3l9 16H3z"/><path d="M12 10v4M12 17v.5"/></svg></div>
         <h3>Injection Cards ×3</h3>
-        <p>Sealed twists. The Conductor reveals them at set times — they force live decisions.</p>
+        <p>Sealed twists. The IT Director reveals them at set times — they force live decisions.</p>
       </div>
       <div class="card">
         <div class="ic" style="background:var(--cyan)"><svg viewBox="0 0 24 24" fill="none" stroke="#fff"><rect x="3" y="3" width="18" height="14" rx="2"/><path d="M3 12l5-3 4 3 3-2 6 4"/></svg></div>
@@ -926,11 +926,11 @@
       <span class="sec-no">ROLES</span>
       <h2>Four roles, no passengers</h2>
     </div>
-    <p class="sec-sub">Everyone leads one phase and carries one standing job for the whole hour. Pick roles in the first two minutes. If you're a team of three, the Conductor also runs the Scribe's standing job; with five, add a second Critic. The Critic's job is to challenge decisions and spark dialogue — not to block — modelled on the "scientific critic" role used in multi-agent research.</p>
+    <p class="sec-sub">Everyone leads one phase and carries one standing job for the whole hour. Pick roles in the first two minutes. If you're a team of three, the IT Director also runs the Network Security's standing job; with five, add a second Digital Resiliency Officer. The Digital Resiliency Officer's job is to challenge decisions and spark dialogue — not to block — modelled on the "scientific critic" role used in multi-agent research.</p>
     <div class="grid g4">
       <div class="card role" style="--rc:var(--amber);--rc-ink:#a3640f">
         <span class="rtag">Owns the clock</span>
-        <h3>The Conductor</h3>
+        <h3>The IT Director</h3>
         <div class="owns">LEADS · P0 Brief-In &amp; P5 Submit</div>
         <ul>
           <li>Reads instructions aloud, keeps the team on the track.</li>
@@ -941,7 +941,7 @@
       </div>
       <div class="card role" style="--rc:var(--red);--rc-ink:#b53636">
         <span class="rtag">Owns the challenge</span>
-        <h3>The Critic</h3>
+        <h3>The Digital Resiliency Officer</h3>
         <div class="owns">LEADS · P1 Expose</div>
         <ul>
           <li>Challenges each decision — "what would make this fail?" — to spark dialogue, not to block.</li>
@@ -952,7 +952,7 @@
       </div>
       <div class="card role" style="--rc:var(--cyan);--rc-ink:#0a7c8c">
         <span class="rtag">Owns the design</span>
-        <h3>The Architect</h3>
+        <h3>The Network Architect</h3>
         <div class="owns">LEADS · P3 Design</div>
         <ul>
           <li>Holds the pen, draws the topology, keeps it legible.</li>
@@ -963,12 +963,12 @@
       </div>
       <div class="card role" style="--rc:var(--green);--rc-ink:#1f8a63">
         <span class="rtag">Owns the write-up</span>
-        <h3>The Scribe</h3>
+        <h3>The Network Security</h3>
         <div class="owns">LEADS · P4 Document</div>
         <ul>
           <li>Captures every key decision the moment it's made.</li>
           <li>Writes and owns the one-page solution sheet.</li>
-          <li>Runs the upload and final submission with the Conductor.</li>
+          <li>Runs the upload and final submission with the IT Director.</li>
         </ul>
         <div class="always"><b>Always:</b> records the "why" behind each choice — that's what the rubric rewards.</div>
       </div>
@@ -981,17 +981,17 @@
       <span class="sec-no">PACKAGE</span>
       <h2>What the group receives — and who holds what</h2>
     </div>
-    <p class="sec-sub">Each team gets one shared kit plus a per-person role card. Most information is shared with everyone; two things are deliberately restricted — the injections (held by the Conductor, revealed on a timer) and the reference answer (held by the facilitator until the debrief). That restriction is what makes the decisions real.</p>
+    <p class="sec-sub">Each team gets one shared kit plus a per-person role card. Most information is shared with everyone; two things are deliberately restricted — the injections (held by the IT Director, revealed on a timer) and the reference answer (held by the facilitator until the debrief). That restriction is what makes the decisions real.</p>
     <div class="win">
       <div class="panel accent-cyan">
         <h3 style="display:flex;align-items:center;gap:9px"><span class="ic" style="background:var(--cyan-soft,#E4F5F8);margin:0"><svg viewBox="0 0 24 24" fill="none" stroke="#0A7C8C" stroke-width="1.8"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 7v10l9 4 9-4V7"/><path d="M12 11v10"/></svg></span>What's in the kit</h3>
         <ul class="kit">
           <li><span class="qty">×1</span><div><b>Scenario Dossier</b><small>The company, its agents, and its current posture — shared with everyone.</small></div></li>
           <li><span class="qty">×1</span><div><b>This Playbook / Instruction Card</b><small>Phases, roles, rubric, time cues — visible to the whole table.</small></div></li>
-          <li><span class="qty">×3</span><div><b>Injection Cards (sealed)</b><small>Held face-down by the Conductor; opened only at their cue time.</small></div></li>
-          <li><span class="qty">×4</span><div><b>Role Cards</b><small>One per person — Conductor, Critic, Architect, Scribe.</small></div></li>
-          <li><span class="qty">×1</span><div><b>Diagram Canvas + markers</b><small>One large sheet the Architect draws on; everyone contributes.</small></div></li>
-          <li><span class="qty">×1</span><div><b>Solution Sheet template</b><small>The single page the Scribe completes for the team.</small></div></li>
+          <li><span class="qty">×3</span><div><b>Injection Cards (sealed)</b><small>Held face-down by the IT Director; opened only at their cue time.</small></div></li>
+          <li><span class="qty">×4</span><div><b>Role Cards</b><small>One per person — IT Director, Digital Resiliency Officer, Network Architect, Network Security.</small></div></li>
+          <li><span class="qty">×1</span><div><b>Diagram Canvas + markers</b><small>One large sheet the Network Architect draws on; everyone contributes.</small></div></li>
+          <li><span class="qty">×1</span><div><b>Solution Sheet template</b><small>The single page the Network Security completes for the team.</small></div></li>
         </ul>
       </div>
       <div>
@@ -1000,7 +1000,7 @@
           <ul class="kit">
             <li><span class="qty dig">LINK</span><div><b>Proctor upload (QR or URL)</b><small>Where the diagram photo and solution sheet are submitted.</small></div></li>
             <li><span class="qty dig">SHOWN</span><div><b>Rubric</b><small>Open to the team during play — scoring is transparent, not a surprise.</small></div></li>
-            <li><span class="qty dig">TIMER</span><div><b>One shared timer</b><small>A phone or screen counting up from 00:00, run by the Conductor.</small></div></li>
+            <li><span class="qty dig">TIMER</span><div><b>One shared timer</b><small>A phone or screen counting up from 00:00, run by the IT Director.</small></div></li>
           </ul>
           <div class="withhold">
             <b>Held back until the debrief</b>
@@ -1013,12 +1013,12 @@
       <table class="rubric">
         <thead><tr><th>Information / material</th><th>Held by</th><th>Who sees it</th><th>When</th></tr></thead>
         <tbody>
-          <tr><td><b>Scenario dossier</b></td><td>Conductor reads it</td><td>Everyone</td><td class="w">From 00:00</td></tr>
+          <tr><td><b>Scenario dossier</b></td><td>IT Director reads it</td><td>Everyone</td><td class="w">From 00:00</td></tr>
           <tr><td><b>Playbook &amp; rubric</b></td><td>On the table</td><td>Everyone</td><td class="w">Throughout</td></tr>
           <tr><td><b>Role cards</b></td><td>Each person</td><td>That person</td><td class="w">Before 00:00</td></tr>
-          <tr><td><b>Injection 01 / 02 / 03</b></td><td>Conductor (sealed)</td><td>Everyone, on reveal</td><td class="w">24:00 / 38:00 / 50:00</td></tr>
-          <tr><td><b>Diagram canvas</b></td><td>Architect holds the pen</td><td>Everyone contributes</td><td class="w">From 33:00</td></tr>
-          <tr><td><b>Solution sheet</b></td><td>Scribe writes it</td><td>Everyone contributes</td><td class="w">Throughout, finalised 48:00–56:00</td></tr>
+          <tr><td><b>Injection 01 / 02 / 03</b></td><td>IT Director (sealed)</td><td>Everyone, on reveal</td><td class="w">24:00 / 38:00 / 50:00</td></tr>
+          <tr><td><b>Diagram canvas</b></td><td>Network Architect holds the pen</td><td>Everyone contributes</td><td class="w">From 33:00</td></tr>
+          <tr><td><b>Solution sheet</b></td><td>Network Security writes it</td><td>Everyone contributes</td><td class="w">Throughout, finalised 48:00–56:00</td></tr>
           <tr><td><b>Reference design / answer key</b></td><td>Facilitator / SME</td><td>The team</td><td class="w">Debrief only (after 60:00)</td></tr>
         </tbody>
       </table>
@@ -1041,19 +1041,19 @@
         </div>
         <div class="step">
           <div class="sn">2</div>
-          <div><span class="who all">Everyone</span><h4>Choose your Conductor</h4><p>One person volunteers to run the session — usually whoever organized it or is keenest. <b>No volunteer?</b> The person whose birthday is next becomes the Conductor. This takes ten seconds, not a discussion.</p></div>
+          <div><span class="who all">Everyone</span><h4>Choose your IT Director</h4><p>One person volunteers to run the session — usually whoever organized it or is keenest. <b>No volunteer?</b> The person whose birthday is next becomes the IT Director. This takes ten seconds, not a discussion.</p></div>
         </div>
         <div class="step">
           <div class="sn">3</div>
-          <div><span class="who con">Conductor reads aloud</span><h4>Read the key instructions to the team</h4><p>The Conductor reads three things out loud so everyone hears the same thing: the <b>"how you complete it"</b> goal, the <b>two deliverables</b>, and the <b>six phases on the board</b>. No need to read the whole card — just enough that everyone knows the shape of the hour.</p></div>
+          <div><span class="who con">IT Director reads aloud</span><h4>Read the key instructions to the team</h4><p>The IT Director reads three things out loud so everyone hears the same thing: the <b>"how you complete it"</b> goal, the <b>two deliverables</b>, and the <b>six phases on the board</b>. No need to read the whole card — just enough that everyone knows the shape of the hour.</p></div>
         </div>
         <div class="step">
           <div class="sn">4</div>
-          <div><span class="who con">Conductor reads aloud</span><h4>Read the four roles and claim them</h4><p>The Conductor reads each role card aloud — Conductor, Critic, Architect, Scribe — and the team claims them as they're read. <b>Whoever is keenest on a role takes it.</b> The Conductor keeps their own role. See the box on the right if two people want the same one.</p></div>
+          <div><span class="who con">IT Director reads aloud</span><h4>Read the four roles and claim them</h4><p>The IT Director reads each role card aloud — IT Director, Digital Resiliency Officer, Network Architect, Network Security — and the team claims them as they're read. <b>Whoever is keenest on a role takes it.</b> The IT Director keeps their own role. See the box on the right if two people want the same one.</p></div>
         </div>
         <div class="step">
           <div class="sn">5</div>
-          <div><span class="who con">Conductor</span><h4>Start the timer — you're now in Phase 0</h4><p>The Conductor starts a timer counting <b>up from 00:00 to 60:00</b> and says <b>"We have 60 minutes — Phase 0 starts now."</b> From here, follow the phase cards below in order.</p></div>
+          <div><span class="who con">IT Director</span><h4>Start the timer — you're now in Phase 0</h4><p>The IT Director starts a timer counting <b>up from 00:00 to 60:00</b> and says <b>"We have 60 minutes — Phase 0 starts now."</b> From here, follow the phase cards below in order.</p></div>
         </div>
       </div>
       <div>
@@ -1062,9 +1062,9 @@
           <h3><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>How time-checking works</h3>
           <ol>
             <li>Use <b>one timer everyone can see</b> — a phone or laptop counting up from <b>00:00</b>. Every time in this playbook is "minutes elapsed."</li>
-            <li>The <b>Conductor owns the clock</b> and is the only person watching it closely, so the others can focus on the work.</li>
-            <li>At each checkpoint, the Conductor <b>says the time out loud</b> — e.g. <b>"We're at 20:00, moving to Decide."</b> So the whole team always knows where the clock is.</li>
-            <li>The full list of what to say and when is on the <b>Conductor's time-cue cheat sheet</b> at the end of this card. Red lines on it are injection reveals.</li>
+            <li>The <b>IT Director owns the clock</b> and is the only person watching it closely, so the others can focus on the work.</li>
+            <li>At each checkpoint, the IT Director <b>says the time out loud</b> — e.g. <b>"We're at 20:00, moving to Decide."</b> So the whole team always knows where the clock is.</li>
+            <li>The full list of what to say and when is on the <b>IT Director's time-cue cheat sheet</b> at the end of this card. Red lines on it are injection reveals.</li>
             <li>When a phase's hard-stop time hits, <b>stop and move on</b> — even if you're not finished. An unfinished phase beats an unsubmitted exercise.</li>
           </ol>
         </div>
@@ -1103,12 +1103,12 @@
       <div class="phase-body">
         <div class="lbl">What each role does</div>
         <div class="acts">
-          <div class="act"><span class="chip con">Conductor</span> Start the timer at 00:00, then read the scenario dossier out loud so everyone hears the same story.</div>
+          <div class="act"><span class="chip con">IT Director</span> Start the timer at 00:00, then read the scenario dossier out loud so everyone hears the same story.</div>
           <div class="act"><span class="chip all">Everyone</span> Confirm the roles you claimed in Start Here — don't re-debate them.</div>
-          <div class="act"><span class="chip thr">Critic</span> Say out loud the one risk that worries you most — you'll lead the hunt for more next.</div>
-          <div class="act"><span class="chip scr">Scribe</span> Write the team's mission in one sentence at the top of the solution sheet.</div>
+          <div class="act"><span class="chip thr">Digital Resiliency Officer</span> Say out loud the one risk that worries you most — you'll lead the hunt for more next.</div>
+          <div class="act"><span class="chip scr">Network Security</span> Write the team's mission in one sentence at the top of the solution sheet.</div>
         </div>
-        <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 06:00</b> — everyone can restate the mission in one sentence. <b>@ 08:00</b> Conductor says "moving to Expose" and the team starts Phase 1.</p></div>
+        <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 06:00</b> — everyone can restate the mission in one sentence. <b>@ 08:00</b> IT Director says "moving to Expose" and the team starts Phase 1.</p></div>
         <div class="exit"><b>Exit criteria</b>Scenario understood · everyone can state the company's problem in one sentence · the one-line mission is written on the sheet.</div>
       </div>
     </div>
@@ -1132,10 +1132,10 @@
       <div class="phase-body">
         <div class="lbl">What each role does</div>
         <div class="acts">
-          <div class="act"><span class="chip thr">Critic</span> Go around the table — each person names one weakness in the current setup, with no repeats.</div>
-          <div class="act"><span class="chip arc">Architect</span> Sort the weaknesses as they're called into three buckets: identity, network, and audit.</div>
-          <div class="act"><span class="chip scr">Scribe</span> Write the 5–7 strongest pain points on the sheet as the team names them.</div>
-          <div class="act"><span class="chip con">Conductor</span> At 14:00, stop the listing and have everyone agree on the worst 2–3.</div>
+          <div class="act"><span class="chip thr">Digital Resiliency Officer</span> Go around the table — each person names one weakness in the current setup, with no repeats.</div>
+          <div class="act"><span class="chip arc">Network Architect</span> Sort the weaknesses as they're called into three buckets: identity, network, and audit.</div>
+          <div class="act"><span class="chip scr">Network Security</span> Write the 5–7 strongest pain points on the sheet as the team names them.</div>
+          <div class="act"><span class="chip con">IT Director</span> At 14:00, stop the listing and have everyone agree on the worst 2–3.</div>
         </div>
         <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 14:00</b> — stop listing, start ranking. <b>@ 20:00</b> hard stop: the top risks are circled and you move to Decide.</p></div>
         <div class="exit"><b>Exit criteria</b>A ranked list of pain points · agreement on the 2–3 that matter most · captured on the sheet.</div>
@@ -1162,12 +1162,12 @@
         <div class="lbl">What each role does</div>
         <div class="acts">
           <div class="act"><span class="chip all">Everyone</span> For each top pain point, agree on one specific control that fixes it.</div>
-          <div class="act"><span class="chip arc">Architect</span> Say the core building blocks out loud: agent identity, a policy checkpoint, network segmentation.</div>
-          <div class="act"><span class="chip thr">Critic</span> Challenge each control — ask "does this actually shrink the damage if an agent is hacked?"</div>
-          <div class="act"><span class="chip scr">Scribe</span> Write each decision down with a one-line reason next to it.</div>
+          <div class="act"><span class="chip arc">Network Architect</span> Say the core building blocks out loud: agent identity, a policy checkpoint, network segmentation.</div>
+          <div class="act"><span class="chip thr">Digital Resiliency Officer</span> Challenge each control — ask "does this actually shrink the damage if an agent is hacked?"</div>
+          <div class="act"><span class="chip scr">Network Security</span> Write each decision down with a one-line reason next to it.</div>
         </div>
         <div class="inj-flag"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3l9 16H3z"/><path d="M12 10v4"/></svg> INJECTION 01 revealed at 24:00 — decide together, then continue</div>
-        <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 24:00</b> Conductor reveals Injection 01 (≈3 min to resolve). <b>@ 30:00</b> controls locked. <b>@ 33:00</b> hand the pen to the Architect.</p></div>
+        <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 24:00</b> IT Director reveals Injection 01 (≈3 min to resolve). <b>@ 30:00</b> controls locked. <b>@ 33:00</b> hand the pen to the Network Architect.</p></div>
         <div class="exit"><b>Exit criteria</b>A chosen set of controls, one per top pain point · Injection 01 answered · reasons written down.</div>
       </div>
     </div>
@@ -1191,10 +1191,10 @@
       <div class="phase-body">
         <div class="lbl">What each role does</div>
         <div class="acts">
-          <div class="act"><span class="chip arc">Architect</span> Draw a labelled box for every component and an arrow for every request between them.</div>
-          <div class="act"><span class="chip thr">Critic</span> Trace one agent's request through the drawing and point out any gap you find.</div>
-          <div class="act"><span class="chip scr">Scribe</span> Keep a legend — make sure every box on the diagram has a clear name.</div>
-          <div class="act"><span class="chip con">Conductor</span> Call the time at 43:00 and 45:00 so the drawing finishes before 48:00.</div>
+          <div class="act"><span class="chip arc">Network Architect</span> Draw a labelled box for every component and an arrow for every request between them.</div>
+          <div class="act"><span class="chip thr">Digital Resiliency Officer</span> Trace one agent's request through the drawing and point out any gap you find.</div>
+          <div class="act"><span class="chip scr">Network Security</span> Keep a legend — make sure every box on the diagram has a clear name.</div>
+          <div class="act"><span class="chip con">IT Director</span> Call the time at 43:00 and 45:00 so the drawing finishes before 48:00.</div>
         </div>
         <div class="lifecycle">
           <div class="lc-note">What you produce here is the <b>logical design</b> — the conceptual first step. In a real engagement it then advances through:</div>
@@ -1232,11 +1232,11 @@
       <div class="phase-body">
         <div class="lbl">What each role does</div>
         <div class="acts">
-          <div class="act"><span class="chip scr">Scribe</span> Fill in every field on the solution sheet — start with the approach and key decisions.</div>
-          <div class="act"><span class="chip arc">Architect</span> Add the diagram's legend and point to it from the write-up so the two match.</div>
-          <div class="act"><span class="chip thr">Critic</span> Write one line for each injection: the threat, then your answer.</div>
+          <div class="act"><span class="chip scr">Network Security</span> Fill in every field on the solution sheet — start with the approach and key decisions.</div>
+          <div class="act"><span class="chip arc">Network Architect</span> Add the diagram's legend and point to it from the write-up so the two match.</div>
+          <div class="act"><span class="chip thr">Digital Resiliency Officer</span> Write one line for each injection: the threat, then your answer.</div>
           <div class="act"><span class="chip all">Everyone</span> Add your own one-line reflection with initials — the decision you drove or would change (60 seconds each).</div>
-          <div class="act"><span class="chip con">Conductor</span> Read the finished sheet back aloud — fix anything a stranger wouldn't understand.</div>
+          <div class="act"><span class="chip con">IT Director</span> Read the finished sheet back aloud — fix anything a stranger wouldn't understand.</div>
         </div>
         <div class="inj-flag"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3l9 16H3z"/><path d="M12 10v4"/></svg> INJECTION 03 revealed at 50:00 — answer it in writing on the sheet</div>
         <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 50:00</b> Injection 03 lands — capture your answer on the page. <b>@ 56:00</b> sheet is done. Move straight to Submit.</p></div>
@@ -1263,10 +1263,10 @@
       <div class="phase-body">
         <div class="lbl">What each role does</div>
         <div class="acts">
-          <div class="act"><span class="chip con">Conductor</span> Count down the last 4 minutes out loud: "3 minutes", "2 minutes", "1 minute".</div>
-          <div class="act"><span class="chip arc">Architect</span> Take a clear, flat, well-lit photo of the diagram and copy it to the clipboard.</div>
-          <div class="act"><span class="chip scr">Scribe</span> Upload the solution sheet and confirm the proctor shows it as received.</div>
-          <div class="act"><span class="chip thr">Critic</span> Do a final check that the diagram and the sheet tell the same story.</div>
+          <div class="act"><span class="chip con">IT Director</span> Count down the last 4 minutes out loud: "3 minutes", "2 minutes", "1 minute".</div>
+          <div class="act"><span class="chip arc">Network Architect</span> Take a clear, flat, well-lit photo of the diagram and copy it to the clipboard.</div>
+          <div class="act"><span class="chip scr">Network Security</span> Upload the solution sheet and confirm the proctor shows it as received.</div>
+          <div class="act"><span class="chip thr">Digital Resiliency Officer</span> Do a final check that the diagram and the sheet tell the same story.</div>
         </div>
         <div class="timecheck"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg><p><b>@ 58:00</b> photo taken and on the clipboard. <b>@ 60:00</b> both artifacts submitted. Anything not submitted is not scored.</p></div>
         <div class="exit"><b>Exit criteria</b>Diagram image captured to clipboard · solution sheet uploaded · both confirmed received.</div>
@@ -1286,10 +1286,10 @@
         <thead>
           <tr>
             <th class="ph">Phase</th>
-            <th class="hcon">Conductor</th>
-            <th class="hthr">The Critic</th>
-            <th class="harc">Architect</th>
-            <th class="hscr">Scribe</th>
+            <th class="hcon">IT Director</th>
+            <th class="hthr">The Digital Resiliency Officer</th>
+            <th class="harc">Network Architect</th>
+            <th class="hscr">Network Security</th>
           </tr>
         </thead>
         <tbody>
@@ -1339,10 +1339,10 @@
       </table>
     </div>
     <div class="takeaways">
-      <div class="ta" style="--tc:var(--amber);--tc-ink:#a3640f"><h4>Conductor practises</h4><p>Facilitation under time pressure, scope control, and keeping a team to an outcome.</p></div>
-      <div class="ta" style="--tc:var(--red);--tc-ink:#b53636"><h4>The Critic practises</h4><p>Constructive challenge, threat-spotting, and driving team dialogue toward a stronger design.</p></div>
-      <div class="ta" style="--tc:var(--cyan);--tc-ink:#0a7c8c"><h4>Architect practises</h4><p>Translating requirements into a clear topology and defending placement choices.</p></div>
-      <div class="ta" style="--tc:var(--green);--tc-ink:#1f8a63"><h4>Scribe practises</h4><p>Crisp technical writing and turning a messy discussion into a decision record.</p></div>
+      <div class="ta" style="--tc:var(--amber);--tc-ink:#a3640f"><h4>IT Director practises</h4><p>Facilitation under time pressure, scope control, and keeping a team to an outcome.</p></div>
+      <div class="ta" style="--tc:var(--red);--tc-ink:#b53636"><h4>The Digital Resiliency Officer practises</h4><p>Constructive challenge, threat-spotting, and driving team dialogue toward a stronger design.</p></div>
+      <div class="ta" style="--tc:var(--cyan);--tc-ink:#0a7c8c"><h4>Network Architect practises</h4><p>Translating requirements into a clear topology and defending placement choices.</p></div>
+      <div class="ta" style="--tc:var(--green);--tc-ink:#1f8a63"><h4>Network Security practises</h4><p>Crisp technical writing and turning a messy discussion into a decision record.</p></div>
     </div>
   </section>
 
@@ -1352,7 +1352,7 @@
       <span class="sec-no">TWISTS</span>
       <h2>The injections</h2>
     </div>
-    <p class="sec-sub">Sealed until their moment. Each one is a real decision under pressure — the Conductor reads it aloud, the team has roughly three minutes to decide, and the answer must show up in your design or your sheet. They exist to see how you think when the brief changes. <b>All three are always used</b>, so every team is scored on the same twists.</p>
+    <p class="sec-sub">Sealed until their moment. Each one is a real decision under pressure — the IT Director reads it aloud, the team has roughly three minutes to decide, and the answer must show up in your design or your sheet. They exist to see how you think when the brief changes. <b>All three are always used</b>, so every team is scored on the same twists.</p>
     <div class="grid g3">
       <div class="inj">
         <div class="inj-head"><div class="l"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3l9 16H3z"/><path d="M12 10v4M12 17v.4"/></svg><span class="tt">01 · Autonomous Expansion</span></div><span class="when">@ 24:00</span></div>
@@ -1725,7 +1725,7 @@
       <span class="sec-no">CONDUCTOR</span>
       <h2>Time-cue cheat sheet</h2>
     </div>
-    <p class="sec-sub">The Conductor reads these out loud. Red lines are injection reveals. Say the time at every checkpoint — the whole team should always know where the clock is.</p>
+    <p class="sec-sub">The IT Director reads these out loud. Red lines are injection reveals. Say the time at every checkpoint — the whole team should always know where the clock is.</p>
     <div class="cues">
       <div class="cue"><span class="t">00:00</span><span class="d"><b>Start.</b> (Roles already claimed.) Timer on, counting up. Read the dossier aloud. "We have 60 minutes."</span></div>
       <div class="cue"><span class="t">06:00</span><span class="d">Everyone can restate the mission in one sentence.</span></div>
@@ -1734,7 +1734,7 @@
       <div class="cue"><span class="t">20:00</span><span class="d"><b>→ Decide.</b> Map each top pain point to a control.</span></div>
       <div class="cue fire"><span class="t">24:00</span><span class="d"><b>INJECTION 01 — Autonomous Expansion.</b> Read it. ~3 min to decide.</span></div>
       <div class="cue"><span class="t">30:00</span><span class="d">"Controls locked — half time gone."</span></div>
-      <div class="cue"><span class="t">33:00</span><span class="d"><b>→ Design.</b> Architect takes the pen.</span></div>
+      <div class="cue"><span class="t">33:00</span><span class="d"><b>→ Design.</b> Network Architect takes the pen.</span></div>
       <div class="cue fire"><span class="t">38:00</span><span class="d"><b>INJECTION 02 — Token in the Wild.</b> Adapt the diagram.</span></div>
       <div class="cue"><span class="t">45:00</span><span class="d">"Stop adding, start labelling."</span></div>
       <div class="cue"><span class="t">48:00</span><span class="d"><b>→ Document.</b> "Pens down — diagram is final."</span></div>
@@ -1752,13 +1752,13 @@
       <span class="sec-no">FACILITATOR</span>
       <h2>Setup checklist (one page)</h2>
     </div>
-    <p class="sec-sub">For the person running the session — distinct from the in-game Conductor. Runs for any number of teams in parallel; one facilitator can comfortably cover three to four tables.</p>
+    <p class="sec-sub">For the person running the session — distinct from the in-game IT Director. Runs for any number of teams in parallel; one facilitator can comfortably cover three to four tables.</p>
     <div class="grid g3">
       <div class="panel" style="border-top:4px solid var(--cyan)">
         <h3 style="display:flex;align-items:center;gap:9px"><span class="ic" style="background:var(--cyan-soft,#E4F5F8);margin:0"><svg viewBox="0 0 24 24" fill="none" stroke="#0A7C8C" stroke-width="1.8"><path d="M9 11l3 3 8-8"/><path d="M20 12v6a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h9"/></svg></span>Before the session</h3>
         <ul class="checklist">
           <li>Print one kit per team: dossier, playbook, 3 injection cards, 4 role cards, canvas + markers, solution sheet.</li>
-          <li>Seal the three injection cards and hand them only to each team's Conductor.</li>
+          <li>Seal the three injection cards and hand them only to each team's IT Director.</li>
           <li>Set up and test the proctor upload (QR or URL); confirm scoring is reachable.</li>
           <li>Have the reference design / answer key ready but kept out of sight.</li>
           <li>Give each table room to draw and one visible timer.</li>
@@ -2280,10 +2280,10 @@
 
   // ---------- persona "take your seat" login ----------
   var ROLES = {
-    conductor:{label:"The Conductor", short:"Conductor", color:"#E2891F", chip:"con", col:1, card:"The Conductor", tag:"Owns the clock · leads Brief-In & Submit"},
-    critic:{label:"The Critic", short:"Critic", color:"#DB4A4A", chip:"thr", col:2, card:"The Critic", tag:"Owns the challenge · leads Expose"},
-    architect:{label:"The Architect", short:"Architect", color:"#0FA9BE", chip:"arc", col:3, card:"The Architect", tag:"Owns the design · leads Design"},
-    scribe:{label:"The Scribe", short:"Scribe", color:"#27A276", chip:"scr", col:4, card:"The Scribe", tag:"Owns the write-up · leads Document"},
+    conductor:{label:"The IT Director", short:"IT Director", color:"#E2891F", chip:"con", col:1, card:"The IT Director", tag:"Owns the clock · leads Brief-In & Submit"},
+    critic:{label:"The Digital Resiliency Officer", short:"Digital Resiliency Officer", color:"#DB4A4A", chip:"thr", col:2, card:"The Digital Resiliency Officer", tag:"Owns the challenge · leads Expose"},
+    architect:{label:"The Network Architect", short:"Network Architect", color:"#0FA9BE", chip:"arc", col:3, card:"The Network Architect", tag:"Owns the design · leads Design"},
+    scribe:{label:"The Network Security", short:"Network Security", color:"#27A276", chip:"scr", col:4, card:"The Network Security", tag:"Owns the write-up · leads Document"},
     facilitator:{label:"Facilitator / Observer", short:"Facilitator", color:"#7E8CA1", chip:null, col:0, card:null, tag:"Runs the session — not an in-game seat"}
   };
   var personaModal=$("#personaModal"), personaLabel=$("#personaLabel"), pmRoles=$("#pmRoles");


### PR DESCRIPTION
## Summary

Renames the four participant roles to job titles across the participant page, proctor, and docs. Internal role keys and all game mechanics (who leads which phase, etc.) are unchanged.

| Was | Now |
|---|---|
| Conductor | **IT Director** |
| Critic | **Digital Resiliency Officer** |
| Architect | **Network Architect** |
| Scribe | **Network Security** |

## Notes
- Applied with **word-boundary** replacements so `architecture` / `Architecture` and the `"scientific critic"` reference are left untouched.
- The role-card headings still carry the original "The …" prefix (e.g. "The IT Director"). Say the word if you'd like me to drop "The" for the job-title versions.

## Testing
Browser test: the seat-picker buttons, persona label, **role-card highlight matching** (depends on label consistency), phase chips, and the proctor roster + summary all show the new names. No JS errors. `scientific critic` and `architecture` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_