### PR TITLE
Let the proctor resume events instead of losing them on reload

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -16,6 +16,7 @@ the in-session phase/time cues live on the participant page itself.)
 - [ ] Open **`proctor.html`**; confirm status reads **"Live · Firebase"**.
 - [ ] Fill in the **event name**, an optional **scheduled date/time**, and note the auto-generated **event code** (↻ to regenerate). Click **Create event**.
 - [ ] Share the **event code** with participants, or click **QR** on the console to show a scannable **join QR** (opens the participant page with the code pre-filled) — great for phones. The **join link** is there too.
+- [ ] **Reopening the console later?** Your events are remembered on that browser — open `proctor.html` and pick the event from the **"Resume an event you created"** list (or type its code in the **room** box and press **Switch**). Use **New event** on the control panel to create another without losing the current one.
 
 ## Opening for teams to join
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -116,6 +116,10 @@ Troubleshooting:
   and note the generated **event code**; click **Create event**. Share the code (or the join link
   the console shows). The event code scopes everything (roster, teams, scores) — it's the `?room=`
   value in the URLs.
+- **Resume an event:** events you create are remembered on that browser. Reopen `proctor.html` and
+  pick it from the **"Resume an event you created"** list, or type its code in the **room** box and
+  press **Switch**. **New event** (on the control panel) starts another without discarding the current
+  one. The event itself lives in Firestore, so it survives refreshes and is shared across devices.
 - **Start / join:** press **Start event** to open joining. Participants enter the **event code**,
   then their details and role, and either **create a team** (get a **team code** to share) or
   **join a team** (enter that team code). A team is **4 fixed roles** (IT Director, Digital Resiliency Officer, Network Architect,

--- a/proctor.html
+++ b/proctor.html
@@ -91,6 +91,14 @@
   #evCode{font-family:"IBM Plex Mono",monospace;font-weight:700;letter-spacing:.16em;text-transform:uppercase;text-align:center}
   .evcode-row{display:flex;gap:6px}.evcode-row input{flex:1}
   @media (max-width:700px){ .setup-fields{grid-template-columns:1fr} }
+  .setup-resume{margin-bottom:16px;padding-bottom:14px;border-bottom:1px dashed var(--line)}
+  .setup-resume[hidden]{display:none}
+  .setup-resume .rh{font-family:"IBM Plex Mono",monospace;font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:9px}
+  .setup-resume .rlist{display:flex;flex-wrap:wrap;gap:8px}
+  .revent{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:10px;padding:7px 11px;background:#fff;cursor:pointer;font-size:13px;color:var(--ink);text-align:left}
+  .revent:hover{border-color:var(--cyan-deep);box-shadow:0 0 0 3px rgba(15,169,190,.1)}
+  .revent .rc{font-family:"IBM Plex Mono",monospace;font-weight:700;letter-spacing:.12em;color:var(--cyan-deep)}
+  .revent .rn{color:var(--ink-soft);max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .ctl-join{font-family:"IBM Plex Mono",monospace;font-size:12px;color:#AEC4DC;padding-left:14px;border-left:1px solid rgba(255,255,255,.14)}
   .ctl-join b{color:#fff;letter-spacing:.14em}
   .ctl-join a{color:#7FE2EF}
@@ -223,6 +231,10 @@
 
   <!-- event setup (shown until an event exists) -->
   <div class="setup" id="evSetup" hidden>
+    <div class="setup-resume" id="evRecent" hidden>
+      <div class="rh">Resume an event you created</div>
+      <div class="rlist" id="evRecentList"></div>
+    </div>
     <div class="setup-h">Create your event</div>
     <div class="setup-fields">
       <label><span>Event name</span><input id="evName" type="text" placeholder="e.g. SE Design Clinic — July" maxlength="80"></label>
@@ -240,6 +252,7 @@
     <div class="ctl-btns">
       <button class="btn primary" id="ctlStart"><span id="ctlStartLabel">Start event</span></button>
       <button class="btn" id="ctlReset" hidden>Reset</button>
+      <button class="btn" id="ctlNew" title="Create a different event">New event</button>
     </div>
   </div>
 
@@ -642,6 +655,35 @@
   });
   setInterval(renderControl,250);
 
+  // ---------- remember events this browser created, so they can be resumed ----------
+  var PKEY_LIST="ztds.proctor.events";
+  function loadEvents(){ try{ return JSON.parse(localStorage.getItem(PKEY_LIST)||"[]"); }catch(e){ return []; } }
+  function rememberEvent(code, name){
+    if(!code) return;
+    var list=loadEvents().filter(function(x){ return x.code!==code; });
+    list.unshift({ code:code, name:name||"", at:Date.now() });
+    if(list.length>8) list=list.slice(0,8);
+    try{ localStorage.setItem(PKEY_LIST, JSON.stringify(list)); }catch(e){}
+    renderRecent();
+  }
+  function renderRecent(){
+    var box=$("#evRecent"), list=$("#evRecentList"); if(!box||!list) return;
+    var evs=loadEvents().filter(function(x){ return x.code && x.code!==ROOM; });
+    if(!evs.length){ box.hidden=true; list.innerHTML=""; return; }
+    box.hidden=false;
+    list.innerHTML = evs.map(function(x){
+      return '<button type="button" class="revent" data-resume="'+esc(x.code)+'"><span class="rc">'+esc(x.code)+'</span>'+(x.name?'<span class="rn">'+esc(x.name)+'</span>':'')+'</button>';
+    }).join("");
+  }
+  $("#evRecentList").addEventListener("click", function(e){
+    var t=e.target.closest ? e.target.closest("[data-resume]") : null; if(!t) return;
+    location.search="?room="+encodeURIComponent(t.getAttribute("data-resume"));
+  });
+  $("#ctlNew").addEventListener("click", function(){
+    // keep the current event saved; reload into the create screen (recent list lets you resume it)
+    window.location.href = location.pathname;
+  });
+
   // ---------- event setup (create) ----------
   $("#evCode").value = ROOM || randCode(5);
   $("#evRegen").addEventListener("click", function(){ $("#evCode").value=randCode(5); });
@@ -649,7 +691,7 @@
     var name=($("#evName").value||"").trim(); if(!name){ $("#evName").focus(); alert("Give your event a name."); return; }
     var code=($("#evCode").value||"").trim().toUpperCase(); if(!code){ code=randCode(5); }
     var whenVal=$("#evWhen").value, sched=0; if(whenVal){ var d=new Date(whenVal); if(!isNaN(d.getTime())) sched=d.getTime(); }
-    ROOM=code; updateRoomLabels();
+    ROOM=code; updateRoomLabels(); rememberEvent(code, name);
     try{ history.replaceState(null,"","?room="+encodeURIComponent(ROOM)); }catch(e){}
     startRoster(function(){ writeEvent({ name:name, scheduledAt:sched, status:"closed" }); });
   });
@@ -670,13 +712,14 @@
       adapter.watch("control", ROOM, function(d){
         var docs=d||[]; eventDoc=docs.filter(function(x){ return x.id===ROOM; })[0]||null;
         teamClocks={}; docs.forEach(function(x){ if(x.kind==="team" && x.teamCode) teamClocks[x.teamCode]=x; });
+        if(eventDoc) rememberEvent(ROOM, eventDoc.name);
         renderControl(); render();
       });
       if(after) after();
     });
   }
 
-  render(); renderControl();
+  render(); renderControl(); renderRecent();
   if(ROOM){ startRoster(); } else { setupEl.hidden=false; controlEl.hidden=true; }
 })();
 </script>


### PR DESCRIPTION
## The problem

"I pressed Start event and it's not starting… if I refresh the page the event is lost, I can't see it saved."

I queried the live Firestore `control` collection directly and the events **are** being saved (e.g. an open event with a team under it). So the data layer is fine — the issue is the **proctor UI can't get back to an event after a reload**.

The proctor only loaded an event when the exact `?room=CODE` was present in the URL. Open `proctor.html` fresh — from a bookmark, a new tab, or after navigating to the participant page and back — and it dropped to the blank "Create event" screen with no way to reach the event you'd already made. It looked lost, and "Start" seemed broken because each reload lost the event context.

## The fix

- **Remember events per browser.** Each event created (or opened via `?room`) is saved to `localStorage` (code + name).
- **Resume list.** The setup screen now shows *"Resume an event you created"* — click an entry to reopen it. This is the direct fix for "I can't see it saved."
- **New event button** on the control panel starts another event without discarding the current one (it stays in the resume list).
- Cross-device/refresh resume also still works by typing the code into the **room** box → **Switch** (the event lives in Firestore).
- Docs updated (`SETUP.md`, `FACILITATOR.md`).

## Verification (Playwright, single-device)

1. Create event → URL gets `?room`, control panel shows, event stored in `localStorage`.
2. **Reopen `proctor.html` with no room** (the "lost" scenario) → setup screen shows the **resume list** with the event.
3. Click **Resume** → event reloads, control panel + name restored.
4. **Start event** → status flips to `OPEN` and persists.
5. **New event** → returns to setup with the prior event still listed.

Participant closed→open transition re-tested — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_