### PR TITLE
Live AI evaluation via a serverless proxy (Anthropic/Claude)

### DIFF
--- a/AI-EVAL.md
+++ b/AI-EVAL.md
@@ -1,0 +1,122 @@
+# Live AI evaluation — setup
+
+The proctor console (`proctor.html`) can score a team's use-case response with
+**Claude** and pre-fill the rubric (you still review and **Save**). Because this
+site is static (GitHub Pages) and the Anthropic API key must **never** ship in
+browser JavaScript, the model is called through a tiny **serverless proxy** that
+holds the key as a server secret.
+
+- Proxy code: [`ai-eval-worker.js`](./ai-eval-worker.js) (Cloudflare Workers reference; adaptable)
+- Client config: `window.AI_EVAL_ENDPOINT` in [`firebase-config.js`](./firebase-config.js)
+
+Manual scoring always works; AI evaluation is **optional** and stays in "preview"
+mode until you set the endpoint.
+
+---
+
+## What happens
+
+1. Proctor opens **Evaluate** on a submitted use case and clicks **Evaluate with AI**.
+2. The page POSTs the team's response + the **cheat sheet** + the rubric maxima to your proxy.
+3. The proxy calls the **Anthropic Messages API** (with the key it holds) and forces a
+   structured `submit_score` result: `c1`, `c2`, `c3`, and a short rationale.
+4. The page fills the three score boxes and the notes; the proctor adjusts if needed and **Saves**.
+   The score is stored with `method:"ai"` and the model used.
+
+Data flow (nothing sensitive in the browser):
+
+```
+proctor.html ──POST {response, cheatSheet, rubric}──▶ your proxy ──x-api-key──▶ Anthropic
+             ◀──── {c1,c2,c3,total,rationale} ───────           ◀── tool_use ──
+```
+
+---
+
+## Option A — Cloudflare Workers (recommended, free tier)
+
+1. Install Wrangler and log in:
+   ```
+   npm i -g wrangler
+   wrangler login
+   ```
+2. Create the Worker from the reference file:
+   - `wrangler init clinic-ai-eval` (choose "Hello World" / no starter framework), then
+     replace the generated `src/index.js` with the contents of [`ai-eval-worker.js`](./ai-eval-worker.js).
+   - (Or keep your own layout — the file is a standard `export default { fetch }` module.)
+3. Set the secret and vars:
+   ```
+   wrangler secret put ANTHROPIC_API_KEY        # paste your Anthropic key when prompted
+   # optional, recommended — lock CORS to your site:
+   wrangler deploy --var ALLOW_ORIGIN:https://coolmukky.github.io
+   # optional light abuse guard (see below):
+   wrangler secret put EVAL_SHARED_TOKEN
+   ```
+   You can also set `ALLOW_ORIGIN` in the dashboard (Workers → your worker → Settings → Variables).
+4. Deploy:
+   ```
+   wrangler deploy
+   ```
+   Note the URL, e.g. `https://clinic-ai-eval.<you>.workers.dev`.
+5. Point the app at it — edit [`firebase-config.js`](./firebase-config.js):
+   ```js
+   window.AI_EVAL_ENDPOINT = "https://clinic-ai-eval.<you>.workers.dev";
+   window.AI_EVAL_TOKEN = "";   // set only if you configured EVAL_SHARED_TOKEN
+   ```
+   Commit and push. Hard-refresh `proctor.html`.
+
+---
+
+## Option B — Firebase Cloud Functions (same Google project)
+
+Requires the **Blaze** (pay-as-you-go) plan. Sketch:
+
+```js
+// functions/index.js  (2nd-gen HTTPS function)
+const { onRequest } = require("firebase-functions/v2/https");
+const { defineSecret } = require("firebase-functions/params");
+const ANTHROPIC_API_KEY = defineSecret("ANTHROPIC_API_KEY");
+
+exports.aiEval = onRequest({ secrets: [ANTHROPIC_API_KEY], cors: ["https://coolmukky.github.io"] },
+  async (req, res) => {
+    // Reuse the request/prompt/Anthropic logic from ai-eval-worker.js:
+    // read req.body, build the messages + submit_score tool, call
+    // https://api.anthropic.com/v1/messages with x-api-key: ANTHROPIC_API_KEY.value(),
+    // then res.json({ c1, c2, c3, total, rationale, model }).
+  });
+```
+
+Deploy with `firebase deploy --only functions`, set the secret with
+`firebase functions:secrets:set ANTHROPIC_API_KEY`, then set
+`window.AI_EVAL_ENDPOINT` to the function URL.
+
+---
+
+## Configuration reference
+
+**Proxy environment (server side — never in the browser):**
+
+| Name | Required | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | yes | Your Anthropic API key (a server secret). |
+| `ALLOW_ORIGIN` | recommended | Exact origin allowed via CORS, e.g. `https://coolmukky.github.io`. Defaults to `*`. |
+| `EVAL_SHARED_TOKEN` | optional | If set, requests must send a matching `x-eval-token` header. Light abuse guard. |
+
+**Client (`firebase-config.js`):**
+
+| Name | Purpose |
+|---|---|
+| `window.AI_EVAL_ENDPOINT` | Your proxy URL. Empty = AI evaluation stays in preview mode. |
+| `window.AI_EVAL_TOKEN` | Only if you set `EVAL_SHARED_TOKEN`. It ships in the page, so treat it as low-value (rotate/limit via origin restriction). |
+
+**Models:** the proctor's picker offers Claude Opus 4.8 / Sonnet 5 (and Haiku).
+The proxy allow-lists Claude model ids and defaults to `claude-opus-4-8`.
+
+---
+
+## Notes & limits
+
+- **The AI suggests; the proctor decides.** Scores are pre-filled, not auto-saved — always review before Save.
+- **Cheat sheet drives grading.** The model is told to grade against the reference answer for that use case (in `CHEATSHEETS` in `proctor.html`). Use cases without a cheat sheet still work but grade more loosely.
+- **Diagrams** are sent to the model (Claude is multimodal) when a team attached one, so the "diagram & overall solution" criterion reflects the picture.
+- **Cost/rate:** each click is one API call. The optional `EVAL_SHARED_TOKEN` + `ALLOW_ORIGIN` reduce casual abuse; for anything public, add real auth/rate-limiting at the proxy.
+- **CORS errors?** Make sure `ALLOW_ORIGIN` exactly matches your site's origin (scheme + host, no trailing slash), then hard-refresh.

--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -38,7 +38,7 @@ the in-session phase/time cues live on the participant page itself.)
 
 - [ ] Teams fill the solution sheet, optionally **Attach diagram** (a photo of their topology), and click **Submit for scoring** (last submit wins). Participants get **5-min and 1-min** warnings automatically.
 - [ ] **Late is allowed:** teams can still submit after 60:00 — the submission records **total time taken** and is flagged **LATE +overtime** (not auto-penalized; you decide how to weigh it).
-- [ ] On **proctor**, each team card lists every **submitted use case** with an **Evaluate** button → open it to see the team's **pain→product mapping, products, diagram + time taken** alongside the **proctor-only cheat sheet**, and score **pain→product (40) + products how/why (30) + diagram & solution (30) = 100 per use case**. An **AI-evaluation** preview (model picker) is present; live model scoring is a follow-up. Totals rank live on **`leaderboard.html`** (project it).
+- [ ] On **proctor**, each team card lists every **submitted use case** with an **Evaluate** button → open it to see the team's **pain→product mapping, products, diagram + time taken** alongside the **proctor-only cheat sheet**, and score **pain→product (40) + products how/why (30) + diagram & solution (30) = 100 per use case**. An **AI-evaluation** option (model picker + *Evaluate with AI*) can pre-fill the score with Claude once you enable it (see `AI-EVAL.md`); you still review and Save. Totals rank live on **`leaderboard.html`** (project it).
 - [ ] On **proctor**, click **Report** → **Print / Save as PDF** for a per-team record (now includes scores), or **Export CSV** for raw data.
 - [ ] Run the 10-minute debrief (reference design is in the participant page's Debrief section).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -136,10 +136,11 @@ Troubleshooting:
 - **Scoring & leaderboard:** on `proctor.html`, each team card lists every submitted use case with an
   **Evaluate** button. Open it to see the team's response **and the proctor-only cheat sheet** for
   that use case, then score three criteria — pain→product mapping (40) + products how/why (30) +
-  diagram & overall solution (30) = **100 per use case**. An **AI-evaluation** control (model picker +
-  *Evaluate with AI*) is present as a preview; live model scoring is a follow-up (manual scoring is
-  fully working). **`leaderboard.html`** ranks teams by **total points across use cases** and shows how
-  many each solved (project it on the shared screen).
+  diagram & overall solution (30) = **100 per use case**. An **AI-evaluation** option (model picker +
+  *Evaluate with AI*) can pre-fill the score with **Claude** via a serverless proxy — see
+  [`AI-EVAL.md`](./AI-EVAL.md) to enable it; until it's configured it stays in preview and manual
+  scoring is fully working. **`leaderboard.html`** ranks teams by **total points across use cases** and
+  shows how many each solved (project it on the shared screen).
 
 ## 5. Privacy / after the session
 

--- a/ai-eval-worker.js
+++ b/ai-eval-worker.js
@@ -1,0 +1,159 @@
+/* ============================================================================
+   AI evaluation proxy for the Segmentation Design Clinic (Anthropic / Claude)
+   ----------------------------------------------------------------------------
+   A tiny serverless function that holds the Anthropic API key as a SERVER
+   secret and scores a team's use-case response against the proctor's cheat
+   sheet. The proctor page (proctor.html) POSTs to it; the key never touches
+   the browser.
+
+   Reference implementation: Cloudflare Workers (free tier, single file).
+   Deploy steps and a Firebase Functions alternative are in AI-EVAL.md.
+
+   Environment (secrets / vars):
+     ANTHROPIC_API_KEY   (required)  your Anthropic API key
+     ALLOW_ORIGIN        (optional)  exact origin allowed via CORS,
+                                     e.g. https://coolmukky.github.io  (default "*")
+     EVAL_SHARED_TOKEN   (optional)  if set, requests must send a matching
+                                     "x-eval-token" header (light abuse guard)
+
+   Request  (POST JSON):
+     { model, useCase, useCaseTitle, rubric:{c1:{label,max},c2:{...},c3:{...}},
+       cheatSheet:{painResponse:[[pain,response]...], products:[[name,how,why]...]},
+       response:{ painMap:[{pain,product,note}], products:[{product,how,why}], diagram } }
+   Response (JSON):
+     { c1, c2, c3, total, rationale, model }
+   ========================================================================== */
+
+const ALLOWED_MODELS = ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"];
+const DEFAULT_MODEL = "claude-opus-4-8";
+
+export default {
+  async fetch(request, env) {
+    const cors = {
+      "Access-Control-Allow-Origin": (env && env.ALLOW_ORIGIN) || "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "content-type, x-eval-token",
+      "Access-Control-Max-Age": "86400",
+    };
+    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: cors });
+    if (request.method !== "POST") return json({ error: "POST only" }, 405, cors);
+    if (!env || !env.ANTHROPIC_API_KEY) return json({ error: "server not configured (missing ANTHROPIC_API_KEY)" }, 500, cors);
+    if (env.EVAL_SHARED_TOKEN && request.headers.get("x-eval-token") !== env.EVAL_SHARED_TOKEN)
+      return json({ error: "unauthorized" }, 401, cors);
+
+    let body;
+    try { body = await request.json(); } catch (e) { return json({ error: "invalid JSON body" }, 400, cors); }
+
+    const model = ALLOWED_MODELS.indexOf(body.model) >= 0 ? body.model : DEFAULT_MODEL;
+    const rubric = normalizeRubric(body.rubric);
+
+    const system =
+      "You are an expert subject-matter examiner grading a team's network segmentation solution " +
+      "in a Cisco design clinic. Grade ONLY against the provided reference answer (cheat sheet) and " +
+      "the rubric maxima. Award partial credit generously where the team's intent matches the reference, " +
+      "but do not reward blank or off-topic answers. Judge the diagram (if provided) for the third " +
+      "criterion. Always respond by calling the submit_score tool.";
+
+    const content = [{ type: "text", text: buildUserText(body, rubric) }];
+    const img = parseDataUrl(body && body.response && body.response.diagram);
+    if (img) content.push({ type: "image", source: { type: "base64", media_type: img.mime, data: img.data } });
+
+    const tool = {
+      name: "submit_score",
+      description: "Return the rubric scores (integers within each maximum) and a short rationale.",
+      input_schema: {
+        type: "object",
+        properties: {
+          c1: { type: "integer", minimum: 0, maximum: rubric.c1.max, description: rubric.c1.label },
+          c2: { type: "integer", minimum: 0, maximum: rubric.c2.max, description: rubric.c2.label },
+          c3: { type: "integer", minimum: 0, maximum: rubric.c3.max, description: rubric.c3.label },
+          rationale: { type: "string", description: "2-4 sentences: what was strong, what was missing." },
+        },
+        required: ["c1", "c2", "c3", "rationale"],
+      },
+    };
+
+    let ar;
+    try {
+      ar = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": env.ANTHROPIC_API_KEY,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model, max_tokens: 1024, system,
+          tools: [tool], tool_choice: { type: "tool", name: "submit_score" },
+          messages: [{ role: "user", content }],
+        }),
+      });
+    } catch (e) {
+      return json({ error: "could not reach Anthropic API", detail: String(e && e.message || e) }, 502, cors);
+    }
+    if (!ar.ok) {
+      const t = await ar.text();
+      return json({ error: "model API error (" + ar.status + ")", detail: t.slice(0, 600) }, 502, cors);
+    }
+    const data = await ar.json();
+    const use = (data.content || []).find(function (b) { return b.type === "tool_use"; });
+    if (!use || !use.input) return json({ error: "model returned no structured score" }, 502, cors);
+
+    const c1 = clamp(use.input.c1, rubric.c1.max);
+    const c2 = clamp(use.input.c2, rubric.c2.max);
+    const c3 = clamp(use.input.c3, rubric.c3.max);
+    return json({ c1, c2, c3, total: c1 + c2 + c3, rationale: String(use.input.rationale || ""), model }, 200, cors);
+  },
+};
+
+function normalizeRubric(r) {
+  r = r || {};
+  const d = { c1: { label: "Pain-point → product mapping", max: 40 }, c2: { label: "Products — how & why", max: 30 }, c3: { label: "Diagram & overall solution", max: 30 } };
+  ["c1", "c2", "c3"].forEach(function (k) {
+    if (r[k] && typeof r[k].max === "number") d[k] = { label: String(r[k].label || d[k].label), max: r[k].max };
+  });
+  return d;
+}
+
+function buildUserText(body, rubric) {
+  const cs = body.cheatSheet || {};
+  const resp = body.response || {};
+  const lines = [];
+  lines.push("USE CASE " + (body.useCase || "?") + ": " + (body.useCaseTitle || ""));
+  lines.push("");
+  lines.push("=== RUBRIC (score each; integers) ===");
+  lines.push("c1 — " + rubric.c1.label + " (0-" + rubric.c1.max + ")");
+  lines.push("c2 — " + rubric.c2.label + " (0-" + rubric.c2.max + ")");
+  lines.push("c3 — " + rubric.c3.label + " (0-" + rubric.c3.max + "); judge the attached diagram image if present.");
+  lines.push("");
+  lines.push("=== REFERENCE ANSWER (cheat sheet) ===");
+  lines.push("Pain point → expected response:");
+  (cs.painResponse || []).forEach(function (r) { lines.push("  - " + r[0] + "  =>  " + r[1]); });
+  lines.push("Expected products (name / how / why):");
+  (cs.products || []).forEach(function (r) { lines.push("  - " + r[0] + " | " + r[1] + " | " + r[2]); });
+  lines.push("");
+  lines.push("=== TEAM'S RESPONSE (grade this) ===");
+  lines.push("Pain-point → product mapping:");
+  (resp.painMap || []).forEach(function (r) { lines.push("  - PAIN: " + (r.pain || "") + " | PRODUCT: " + (r.product || "—") + " | HOW/WHY: " + (r.note || "—")); });
+  lines.push("Products proposed (name / how / why):");
+  (resp.products || []).forEach(function (r) { lines.push("  - " + (r.product || "—") + " | " + (r.how || "—") + " | " + (r.why || "—")); });
+  lines.push("Diagram attached: " + (parseDataUrl(resp.diagram) ? "yes (see image)" : "no"));
+  lines.push("");
+  lines.push("Score the team's response against the reference using the rubric. Call submit_score.");
+  return lines.join("\n");
+}
+
+function parseDataUrl(u) {
+  if (typeof u !== "string") return null;
+  const m = u.match(/^data:([^;]+);base64,(.+)$/);
+  if (!m) return null;
+  const mime = m[1];
+  if (["image/jpeg", "image/png", "image/gif", "image/webp"].indexOf(mime) < 0) return null;
+  return { mime: mime, data: m[2] };
+}
+
+function clamp(v, max) { v = parseInt(v, 10); if (isNaN(v) || v < 0) v = 0; if (v > max) v = max; return v; }
+
+function json(o, status, cors) {
+  return new Response(JSON.stringify(o), { status: status, headers: Object.assign({ "content-type": "application/json" }, cors) });
+}

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -67,3 +67,15 @@ window.FIREBASE_CONFIG = {
   messagingSenderId: "278404586451",
   appId: "1:278404586451:web:459afeba6085107d712d26"
 };
+
+/* ----------------------------------------------------------------------------
+   AI evaluation (optional) — proctor.html "Evaluate with AI".
+   Point this at your deployed serverless proxy (see ai-eval-worker.js + AI-EVAL.md).
+   The proxy holds the Anthropic API key as a SERVER secret; the key must NOT be
+   placed here. Leave the endpoint empty to keep AI evaluation in preview mode
+   (manual scoring always works regardless).
+   AI_EVAL_TOKEN is optional and only needed if you set EVAL_SHARED_TOKEN on the
+   proxy — it's a light abuse guard, not a real secret, so keep it low-value.
+   -------------------------------------------------------------------------- */
+window.AI_EVAL_ENDPOINT = "";   // e.g. "https://clinic-ai-eval.<you>.workers.dev"
+window.AI_EVAL_TOKEN = "";      // optional; matches the proxy's EVAL_SHARED_TOKEN

--- a/proctor.html
+++ b/proctor.html
@@ -645,12 +645,39 @@
   $("#emCancel").addEventListener("click", closeEval);
   evalModal.addEventListener("click", function(e){ if(e.target===evalModal) closeEval(); });
   document.addEventListener("keydown", function(e){ if(e.key==="Escape" && !evalModal.hidden) closeEval(); });
-  // AI evaluation — stub (UI + model choice; live model call is a follow-up)
+  // AI evaluation — calls a serverless proxy (holds the API key) when configured.
   var aiUsed=false;
+  function aiEndpoint(){ return (window.AI_EVAL_ENDPOINT||"").trim(); }
   $("#emAi").addEventListener("click", function(){
-    var model=$("#emModel").value;
-    $("#emAiNote").innerHTML = '<b>AI evaluation preview.</b> Model <code>'+esc(model)+'</code> selected. Live model scoring isn\'t wired to an API yet — this is where the proctor would send the team\'s response + cheat sheet to the model and get back a suggested score and rationale. For now, score manually above; the selected model is saved with the score.';
-    aiUsed=true;
+    var model=$("#emModel").value, ep=aiEndpoint(), note=$("#emAiNote"), btn=$("#emAi");
+    if(!ep){
+      note.innerHTML = '<b>AI evaluation preview.</b> No endpoint is configured, so live scoring is off. Set <code>window.AI_EVAL_ENDPOINT</code> in <code>firebase-config.js</code> to your deployed proxy (see <code>AI-EVAL.md</code>). For now score manually — the selected model (<code>'+esc(model)+'</code>) is saved with the score.';
+      aiUsed=true; return;
+    }
+    var sol=(solutions[evalTk]||{})[evalUc];
+    if(!sol){ note.textContent="No submission to evaluate."; return; }
+    var payload={ model:model, useCase:evalUc, useCaseTitle:sol.useCaseTitle||("Use Case "+evalUc),
+      rubric:{ c1:{label:"Pain-point → product mapping", max:MAX_C1}, c2:{label:"Products — how & why", max:MAX_C2}, c3:{label:"Diagram & overall solution", max:MAX_C3} },
+      cheatSheet: CHEATSHEETS[evalUc]||null,
+      response:{ painMap:sol.painMap||[], products:sol.products||[], diagram:sol.diagram||"" } };
+    var headers={"content-type":"application/json"}; if(window.AI_EVAL_TOKEN) headers["x-eval-token"]=window.AI_EVAL_TOKEN;
+    var oldLabel=btn.textContent; btn.disabled=true; btn.textContent="Evaluating…";
+    note.textContent="Asking "+model+" to score against the cheat sheet…";
+    fetch(ep, { method:"POST", headers:headers, body:JSON.stringify(payload) })
+      .then(function(r){ return r.json().then(function(j){ return {ok:r.ok, j:j}; }, function(){ return {ok:false, j:{error:"non-JSON response"}}; }); })
+      .then(function(res){
+        if(res.ok && res.j && typeof res.j.c1==="number"){
+          $("#emC1").value=res.j.c1; $("#emC2").value=res.j.c2; $("#emC3").value=res.j.c3; emUpdateTotal();
+          var rat=res.j.rationale||"";
+          note.innerHTML='<b>AI suggestion ('+esc(res.j.model||model)+'):</b> '+esc(rat)+'<br><span style="color:var(--ink-faint)">Adjust if needed, then Save score.</span>';
+          if(rat && !$("#emNotes").value.trim()) $("#emNotes").value="[AI · "+(res.j.model||model)+"] "+rat;
+          aiUsed=true;
+        } else {
+          note.textContent="AI evaluation failed: "+((res.j&&res.j.error)||"unexpected response")+((res.j&&res.j.detail)?(" — "+res.j.detail):"");
+        }
+      })
+      .catch(function(err){ note.textContent="AI evaluation error: "+((err&&err.message)||err)+". Check the endpoint URL / CORS (AI-EVAL.md)."; })
+      .then(function(){ btn.disabled=false; btn.textContent=oldLabel; });
   });
   $("#emSave").addEventListener("click", function(){
     if(!evalTk || !adapterRef) return;


### PR DESCRIPTION
## What & why

Adds **live AI evaluation** to the proctor console: **Evaluate with AI** scores a team's use-case response with **Claude** and pre-fills the rubric for the proctor to review and Save. Per the chosen approach, the Anthropic API key stays **server-side** — a small **serverless proxy** holds it and calls the model; the static page only ever talks to the proxy.

## Pieces

- **`ai-eval-worker.js`** — portable Cloudflare Worker (`export default { fetch }`). Accepts `{model, useCase, rubric, cheatSheet, response(+diagram)}`, forces a structured `submit_score` tool result from Claude, clamps to the rubric maxima, and returns `{c1, c2, c3, total, rationale}`. Includes CORS, an optional `EVAL_SHARED_TOKEN` guard, a Claude model allow-list, and sends the team's **diagram image** to the model when present (multimodal).
- **`proctor.html`** — *Evaluate with AI* POSTs to `window.AI_EVAL_ENDPOINT` when configured, fills the three score boxes + notes with the rationale, and records `method:"ai"` + model on Save. When unset it stays in **preview** mode (manual scoring is unaffected and always works).
- **`firebase-config.js`** — `AI_EVAL_ENDPOINT` / `AI_EVAL_TOKEN` placeholders (empty by default). The key is **never** placed here.
- **`AI-EVAL.md`** — deploy guide (Cloudflare Workers primary + Firebase Functions alternative), config reference, CORS/token notes, and the data-flow diagram.
- **SETUP / FACILITATOR** — updated to point at `AI-EVAL.md`.

## Data flow (nothing sensitive in the browser)

```
proctor.html ──POST {response, cheatSheet, rubric}──▶ proxy ──x-api-key──▶ Anthropic
             ◀──── {c1,c2,c3,total,rationale} ───────       ◀── tool_use ──
```

## Verification

- **Worker (Node, mocked Anthropic):** happy path returns a structured score; over-max value **clamped** (41→40); correct model + forced `submit_score` tool + image block sent; API key only in the server-side header; **CORS preflight** 204; **missing key** → 500; **token mismatch** → 401; **GET** → 405.
- **Proctor wiring (Playwright, mocked endpoint):** *Evaluate with AI* fills **36/27/25 = 88**, shows the rationale, prefills notes, and **Save** records `method:"ai"` + model. No JS errors. Manual scoring path unchanged.

## To enable (summary — full steps in `AI-EVAL.md`)

1. Deploy `ai-eval-worker.js` (e.g. `wrangler deploy`), set `ANTHROPIC_API_KEY` secret and `ALLOW_ORIGIN=https://coolmukky.github.io`.
2. Set `window.AI_EVAL_ENDPOINT` in `firebase-config.js` to the proxy URL; commit + hard-refresh.

Until then, AI evaluation stays in preview and manual scoring works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_