### PR TITLE
Ship a ready wrangler.toml so the AI proxy deploys in two commands

### DIFF
--- a/AI-EVAL.md
+++ b/AI-EVAL.md
@@ -34,35 +34,36 @@ proctor.html ──POST {response, cheatSheet, rubric}──▶ your proxy ─�
 
 ## Option A — Cloudflare Workers (recommended, free tier)
 
-1. Install Wrangler and log in:
+The repo already ships the Worker ([`ai-eval-worker.js`](./ai-eval-worker.js)) **and** a ready
+[`wrangler.toml`](./wrangler.toml), so deploy is basically: set your key, deploy.
+
+1. Install Wrangler and log in (once):
    ```
    npm i -g wrangler
    wrangler login
    ```
-2. Create the Worker from the reference file:
-   - `wrangler init clinic-ai-eval` (choose "Hello World" / no starter framework), then
-     replace the generated `src/index.js` with the contents of [`ai-eval-worker.js`](./ai-eval-worker.js).
-   - (Or keep your own layout — the file is a standard `export default { fetch }` module.)
-3. Set the secret and vars:
+2. From the **repo root**, set your Anthropic key as a Worker secret:
    ```
    wrangler secret put ANTHROPIC_API_KEY        # paste your Anthropic key when prompted
-   # optional, recommended — lock CORS to your site:
-   wrangler deploy --var ALLOW_ORIGIN:https://coolmukky.github.io
    # optional light abuse guard (see below):
-   wrangler secret put EVAL_SHARED_TOKEN
+   # wrangler secret put EVAL_SHARED_TOKEN
    ```
-   You can also set `ALLOW_ORIGIN` in the dashboard (Workers → your worker → Settings → Variables).
-4. Deploy:
+3. Deploy (uses `wrangler.toml` automatically — name, entry file, and `ALLOW_ORIGIN` are preset):
    ```
    wrangler deploy
    ```
-   Note the URL, e.g. `https://clinic-ai-eval.<you>.workers.dev`.
-5. Point the app at it — edit [`firebase-config.js`](./firebase-config.js):
+   Note the printed URL, e.g. `https://clinic-ai-eval.<you>.workers.dev`.
+
+   > `wrangler.toml` presets `ALLOW_ORIGIN = https://coolmukky.github.io`. If you serve the pages
+   > from a different origin, edit that line before deploying.
+
+4. Point the app at it — edit [`firebase-config.js`](./firebase-config.js):
    ```js
    window.AI_EVAL_ENDPOINT = "https://clinic-ai-eval.<you>.workers.dev";
    window.AI_EVAL_TOKEN = "";   // set only if you configured EVAL_SHARED_TOKEN
    ```
-   Commit and push. Hard-refresh `proctor.html`.
+   Commit and push, then hard-refresh `proctor.html`.
+5. On the proctor, click **Test AI** → expect **"AI endpoint OK · &lt;model&gt; · &lt;ms&gt; ms"**.
 
 ---
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,18 @@
+# Cloudflare Workers config for the AI evaluation proxy.
+# Deploy from the repo root:
+#   npm i -g wrangler && wrangler login
+#   wrangler secret put ANTHROPIC_API_KEY      # paste your Anthropic key
+#   wrangler deploy
+# (Optional light abuse guard: wrangler secret put EVAL_SHARED_TOKEN)
+#
+# Nothing secret lives in this file. The API key is a Worker *secret*, set via
+# the CLI above — never put it here. See AI-EVAL.md for the full guide.
+
+name = "clinic-ai-eval"
+main = "ai-eval-worker.js"
+compatibility_date = "2024-11-01"
+
+[vars]
+# Lock CORS to your site's origin (scheme + host, no trailing slash).
+# Change this if you serve the pages from a different origin.
+ALLOW_ORIGIN = "https://coolmukky.github.io"


### PR DESCRIPTION
## What & why

Makes deploying the AI-evaluation proxy near-trivial. Adds a committed `wrangler.toml` (name, `main = ai-eval-worker.js`, `compatibility_date`, and `ALLOW_ORIGIN` preset to the Pages origin) so the deploy is just:

```
wrangler secret put ANTHROPIC_API_KEY
wrangler deploy
```

No secrets live in the file — the API key is a Worker secret set via the CLI. `AI-EVAL.md` Option A is streamlined to match (no more `wrangler init` / manual file copy).

Validated `wrangler.toml` parses as TOML and the entry file it references exists.

Docs/config only — no runtime code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_