### PR TITLE
Proctor auto-reopens your most recent event on a fresh open

### DIFF
--- a/FACILITATOR.md
+++ b/FACILITATOR.md
@@ -16,7 +16,7 @@ the in-session phase/time cues live on the participant page itself.)
 - [ ] Open **`proctor.html`**; confirm status reads **"Live · Firebase"**.
 - [ ] Fill in the **event name**, an optional **scheduled date/time**, and note the auto-generated **event code** (↻ to regenerate). Click **Create event**.
 - [ ] Share the **event code** with participants, or click **QR** on the console to show a scannable **join QR** (opens the participant page with the code pre-filled) — great for phones. The **join link** is there too.
-- [ ] **Reopening the console later?** Your events are remembered on that browser — open `proctor.html` and pick the event from the **"Resume an event you created"** list (or type its code in the **room** box and press **Switch**). Use **New event** on the control panel to create another without losing the current one.
+- [ ] **Reopening the console later?** Opening `proctor.html` **automatically reopens your most recent event** (refresh, new tab, or bookmark — you won't lose it). Use **New event** to start a fresh one; older events are on the create screen's **"Resume"** list, or type a code in the **room** box → **Switch**.
 
 ## Opening for teams to join
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -116,10 +116,11 @@ Troubleshooting:
   and note the generated **event code**; click **Create event**. Share the code (or the join link
   the console shows). The event code scopes everything (roster, teams, scores) — it's the `?room=`
   value in the URLs.
-- **Resume an event:** events you create are remembered on that browser. Reopen `proctor.html` and
-  pick it from the **"Resume an event you created"** list, or type its code in the **room** box and
-  press **Switch**. **New event** (on the control panel) starts another without discarding the current
-  one. The event itself lives in Firestore, so it survives refreshes and is shared across devices.
+- **Resume an event:** reopening `proctor.html` (refresh, new tab, bookmark) **automatically reopens
+  your most recent event** on that browser — you never lose it. Press **New event** to start another;
+  pick an older one from the **"Resume an event you created"** list on the create screen, or type its
+  code in the **room** box and press **Switch**. The event lives in Firestore, so it survives refreshes
+  and is reachable from any device by its code.
 - **Start / join:** press **Start event** to open joining. Participants enter the **event code**,
   then their details and role, and either **create a team** (get a **team code** to share) or
   **join a team** (enter that team code). A team is **4 fixed roles** (IT Director, Digital Resiliency Officer, Network Architect,

--- a/proctor.html
+++ b/proctor.html
@@ -938,8 +938,8 @@
     location.search="?room="+encodeURIComponent(t.getAttribute("data-resume"));
   });
   $("#ctlNew").addEventListener("click", function(){
-    // keep the current event saved; reload into the create screen (recent list lets you resume it)
-    window.location.href = location.pathname;
+    // keep the current event saved; go to the create screen (?new skips auto-restore)
+    window.location.href = location.pathname + "?new=1";
   });
 
   // ---------- event setup (create) ----------
@@ -977,6 +977,16 @@
     });
   }
 
+  // Auto-restore the last event on a fresh open (no ?room), so a refresh/reopen never
+  // "loses" it. ?new=1 (the New event button) skips this and shows the create screen.
+  var wantNew = (new URLSearchParams(location.search)).has("new");
+  if(!ROOM && !wantNew){
+    var _evs = loadEvents();
+    if(_evs.length && _evs[0].code){
+      ROOM = _evs[0].code; updateRoomLabels();
+      try{ history.replaceState(null,"","?room="+encodeURIComponent(ROOM)); }catch(e){}
+    }
+  }
   render(); renderControl(); renderRecent();
   if(ROOM){ startRoster(); } else { setupEl.hidden=false; controlEl.hidden=true; }
 })();


### PR DESCRIPTION
## What & why

Fixes the recurring "refresh loses my event" confusion. The event was always **saved in Firestore** (verified — the reported event was in the DB), but the proctor page only reloaded it when the event code was in the URL (`?room=CODE`). Opening `proctor.html` fresh (bookmark, new tab, or the plain link) dropped to the create screen, so it *looked* lost.

Now: **opening `proctor.html` with no `?room` auto-reopens the most recent event created on that browser.** Refresh / reopen / bookmark all land back in the event.

- The **New event** button now navigates to `?new=1`, which skips auto-restore and shows the create screen (so you can still start a fresh event).
- Older events remain on the create screen's **"Resume an event you created"** list, and any event is still reachable cross-device by typing its code in the **room** box → **Switch**.

## Verification (Playwright)
- Create + Start → **reopen bare `proctor.html`** → lands back in the event (URL becomes `?room=CODE`, status preserved). ✅
- **New event** → `?new=1` → create screen, prior event shown in Resume. ✅
- Create a second event → **bare reopen restores the newest**. ✅
- No JS errors. Docs (SETUP, FACILITATOR) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_