### PR TITLE
Cisco color theme + neon professional reference diagram

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -10,8 +10,8 @@
 <style>
   :root{
     --surface:#FFFFFF;--ink:#0E1A2B;--ink-soft:#46566E;--ink-faint:#7E8CA1;
-    --line:#CBD5E3;--line-soft:#E1E8F1;--navy:#122A47;--navy-deep:#0A1830;
-    --cyan:#0FA9BE;--cyan-deep:#0A7C8C;--amber:#E2891F;--red:#DB4A4A;--green:#27A276;
+    --line:#CBD5E3;--line-soft:#E1E8F1;--navy:#0D274D;--navy-deep:#041E42;
+    --cyan:#00BCEB;--cyan-deep:#036C8F;--amber:#E2891F;--red:#DB4A4A;--green:#27A276;
     --gold:#E9B949;--silver:#AEB6C2;--bronze:#C88A5B;
     --shadow:0 1px 0 rgba(14,26,43,.04), 0 18px 40px -28px rgba(14,26,43,.55);
   }
@@ -19,7 +19,7 @@
   body{margin:0;font-family:"IBM Plex Sans",system-ui,sans-serif;color:var(--ink);background:#F3F6FA;-webkit-font-smoothing:antialiased}
   h1,h2,h3{font-family:"Chakra Petch",sans-serif;margin:0;line-height:1.1}
   .wrap{max-width:900px;margin:0 auto;padding:0 22px}
-  .top{background:radial-gradient(120% 160% at 88% -20%,#1c3a5e 0%,var(--navy) 45%,var(--navy-deep) 100%);color:#EAF1F8;border-bottom:3px solid var(--cyan)}
+  .top{background:radial-gradient(130% 160% at 86% -20%,#0a5a99 0%,#0d3f73 34%,var(--navy) 62%,var(--navy-deep) 100%);color:#EAF1F8;border-bottom:3px solid var(--cyan)}
   .top-in{padding:26px 0 24px;display:flex;flex-wrap:wrap;align-items:flex-end;gap:16px}
   .eyebrow{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:500;letter-spacing:.22em;text-transform:uppercase;color:#7FE2EF}
   .top h1{font-size:clamp(26px,4.5vw,42px);font-weight:700;color:#fff;margin:.25em 0 .1em}

--- a/proctor.html
+++ b/proctor.html
@@ -10,8 +10,8 @@
 <style>
   :root{
     --paper:#E9EEF5;--surface:#FFFFFF;--ink:#0E1A2B;--ink-soft:#46566E;--ink-faint:#7E8CA1;
-    --line:#CBD5E3;--line-soft:#E1E8F1;--navy:#122A47;--navy-deep:#0A1830;
-    --cyan:#0FA9BE;--cyan-deep:#0A7C8C;--amber:#E2891F;--red:#DB4A4A;--green:#27A276;
+    --line:#CBD5E3;--line-soft:#E1E8F1;--navy:#0D274D;--navy-deep:#041E42;
+    --cyan:#00BCEB;--cyan-deep:#036C8F;--amber:#E2891F;--red:#DB4A4A;--green:#27A276;
     --shadow:0 1px 0 rgba(14,26,43,.04), 0 18px 40px -28px rgba(14,26,43,.55);
   }
   *{box-sizing:border-box}
@@ -20,7 +20,7 @@
   .mono{font-family:"IBM Plex Mono",monospace}
   .wrap{max-width:1080px;margin:0 auto;padding:0 22px}
 
-  .top{background:radial-gradient(120% 160% at 88% -20%,#1c3a5e 0%,var(--navy) 45%,var(--navy-deep) 100%);color:#EAF1F8;border-bottom:3px solid var(--cyan)}
+  .top{background:radial-gradient(130% 160% at 86% -20%,#0a5a99 0%,#0d3f73 34%,var(--navy) 62%,var(--navy-deep) 100%);color:#EAF1F8;border-bottom:3px solid var(--cyan)}
   .top-in{padding:26px 0 24px;display:flex;flex-wrap:wrap;align-items:flex-end;gap:18px}
   .eyebrow{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:500;letter-spacing:.22em;text-transform:uppercase;color:#7FE2EF}
   .top h1{font-size:clamp(24px,4vw,38px);font-weight:700;color:#fff;margin:.28em 0 .1em}

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -16,10 +16,10 @@
     --ink-faint:#7E8CA1;
     --line:#CBD5E3;
     --line-soft:#E1E8F1;
-    --navy:#122A47;
-    --navy-deep:#0A1830;
-    --cyan:#0FA9BE;
-    --cyan-deep:#0A7C8C;
+    --navy:#0D274D;        /* Cisco midnight blue */
+    --navy-deep:#041E42;
+    --cyan:#00BCEB;        /* Cisco blue */
+    --cyan-deep:#036C8F;   /* darker Cisco blue for text/links */
     --amber:#E2891F;
     --amber-soft:#FBEBD3;
     --red:#DB4A4A;
@@ -54,7 +54,7 @@
 
   /* ---------- HERO ---------- */
   .hero{
-    background:radial-gradient(120% 140% at 88% -10%,#1c3a5e 0%,var(--navy) 42%,var(--navy-deep) 100%);
+    background:radial-gradient(130% 150% at 86% -12%,#0a5a99 0%,#0d3f73 34%,var(--navy) 62%,var(--navy-deep) 100%);
     color:#EAF1F8;border-radius:0 0 26px 26px;border-bottom:3px solid var(--cyan);
     position:relative;overflow:hidden;
   }
@@ -543,6 +543,8 @@
   .topo-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:14px;background:#fff;padding:10px}
   .topo-wrap svg{display:block;min-width:760px;width:100%;height:auto}
   .topo-wrap img{display:block;width:100%;min-width:720px;height:auto;border-radius:8px}
+  .topo-neon{background:#061530;border:1px solid #123156;padding:0;box-shadow:0 20px 50px -24px rgba(0,120,180,.5)}
+  .topo-neon svg{min-width:820px;border-radius:14px}
   .topo-legend{display:flex;flex-wrap:wrap;gap:14px;margin-top:12px;font-size:12px;color:var(--ink-soft)}
   .topo-legend span{display:inline-flex;align-items:center;gap:6px}
   .topo-legend i{width:14px;height:14px;border-radius:4px;display:inline-block}
@@ -885,10 +887,130 @@
       <h2>Current customer architecture</h2>
     </div>
     <p class="sec-sub">The reference network you're designing for — everyone starts from the same picture. Your diagram for each use case is your version of this, with the products and policy you propose drawn on top.</p>
-    <div class="topo-wrap">
-      <img src="reference-network.jpg" alt="Current customer architecture — reference network diagram: remote branches and Zero Trust Access users connect via SD-WAN and SSE to the corporate HQ head-end routers, the on-premises application environment, and apps in Azure and AWS via cloud-exchange peering. Microsoft Entra ID provides identity; SaaS and Internet are reached through SSE.">
+    <div class="topo-wrap topo-neon">
+      <svg viewBox="0 0 1040 660" role="img" aria-label="Neon reference network diagram: remote users with Zero Trust Access, remote branches and a branch site on the left; SD-WAN, SSE and the corporate HQ head-end routers in the core; Microsoft Entra ID, SaaS and Internet across the top; Azure, AWS and the on-premises application environment on the right.">
+        <defs>
+          <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#0a1e3f"/><stop offset="0.55" stop-color="#0b2247"/><stop offset="1" stop-color="#061530"/>
+          </linearGradient>
+          <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+            <feGaussianBlur stdDeviation="3.4" result="b"/>
+            <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+          </filter>
+          <marker id="ar" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+            <path d="M0 0L10 5L0 10z" fill="#69f0ff"/>
+          </marker>
+        </defs>
+        <rect x="0" y="0" width="1040" height="660" rx="16" fill="url(#bg)"/>
+        <!-- faint grid -->
+        <g stroke="#1d3f6b" stroke-width="1" opacity="0.5">
+          <path d="M0 90H1040M0 200H1040M0 330H1040M0 460H1040M0 560H1040"/>
+          <path d="M180 0V660M430 0V660M640 0V660M820 0V660"/>
+        </g>
+
+        <!-- column labels -->
+        <text x="120" y="34" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="12" letter-spacing="2" fill="#5fd7ff">USERS &amp; SITES</text>
+        <text x="545" y="34" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="12" letter-spacing="2" fill="#5fd7ff">NETWORK CORE</text>
+        <text x="915" y="34" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="12" letter-spacing="2" fill="#5fd7ff">RESOURCES</text>
+
+        <!-- CONNECTORS (drawn first, under nodes) -->
+        <g fill="none" stroke-width="2">
+          <!-- remote users -> SSE (VPN dashed) -->
+          <path d="M222 150 C 330 150, 350 150, 430 152" stroke="#ffb648" stroke-dasharray="7 6" marker-end="url(#ar)"/>
+          <!-- branches -> SD-WAN (dashed) -->
+          <path d="M222 285 C 245 285, 250 292, 285 296" stroke="#3ff0b0" stroke-dasharray="7 6" marker-end="url(#ar)"/>
+          <!-- branch site -> SD-WAN (overlay VPN dashed) -->
+          <path d="M222 470 C 300 470, 330 340, 350 332" stroke="#3ff0b0" stroke-dasharray="7 6" marker-end="url(#ar)"/>
+          <!-- SD-WAN -> SSE (solid) -->
+          <path d="M400 258 C 430 220, 450 205, 470 200" stroke="#00bceb" marker-end="url(#ar)"/>
+          <!-- SD-WAN -> Corp HQ (solid) -->
+          <path d="M460 300 C 490 300, 500 300, 512 300" stroke="#00bceb" marker-end="url(#ar)"/>
+          <!-- SSE -> Entra (identity dotted) -->
+          <path d="M560 132 C 590 100, 600 92, 628 86" stroke="#a888ff" stroke-dasharray="2 5" marker-end="url(#ar)"/>
+          <!-- SSE -> SaaS (solid) -->
+          <path d="M600 140 C 720 110, 760 95, 792 84" stroke="#69f0ff" marker-end="url(#ar)"/>
+          <!-- SSE -> Internet (solid) -->
+          <path d="M604 150 C 800 150, 900 110, 936 92" stroke="#69f0ff" marker-end="url(#ar)"/>
+          <!-- Corp HQ -> Azure (cloud exchange solid) -->
+          <path d="M672 286 C 760 250, 790 210, 822 192" stroke="#a888ff" marker-end="url(#ar)"/>
+          <!-- Corp HQ -> AWS (solid) -->
+          <path d="M672 306 C 760 306, 790 292, 822 286" stroke="#a888ff" marker-end="url(#ar)"/>
+          <!-- Corp HQ -> On-prem apps (solid 10G) -->
+          <path d="M592 356 C 640 400, 680 410, 716 414" stroke="#00bceb" stroke-width="3" marker-end="url(#ar)"/>
+        </g>
+
+        <!-- NODES: glowing rects -->
+        <g filter="url(#glow)">
+          <!-- top services -->
+          <rect x="628" y="56" width="150" height="58" rx="12" fill="#161b46" stroke="#a888ff" stroke-width="1.8"/>
+          <rect x="792" y="56" width="130" height="58" rx="12" fill="#12203f" stroke="#69f0ff" stroke-width="1.8"/>
+          <rect x="936" y="56" width="86" height="58" rx="12" fill="#12203f" stroke="#69f0ff" stroke-width="1.8"/>
+          <!-- left users/sites -->
+          <rect x="28" y="120" width="194" height="70" rx="12" fill="#22183a" stroke="#ffb648" stroke-width="1.8"/>
+          <rect x="28" y="238" width="194" height="94" rx="12" fill="#10233f" stroke="#3ff0b0" stroke-width="1.8"/>
+          <rect x="28" y="388" width="194" height="104" rx="12" fill="#10233f" stroke="#3ff0b0" stroke-width="1.8"/>
+          <!-- core -->
+          <rect x="430" y="122" width="176" height="80" rx="14" fill="#08324a" stroke="#00bceb" stroke-width="2.4"/>
+          <rect x="270" y="256" width="150" height="72" rx="12" fill="#0b2f2a" stroke="#3ff0b0" stroke-width="2"/>
+          <rect x="512" y="248" width="176" height="108" rx="14" fill="#08324a" stroke="#00bceb" stroke-width="2.4"/>
+          <!-- right resources -->
+          <rect x="822" y="120" width="190" height="80" rx="12" fill="#1b1440" stroke="#a888ff" stroke-width="1.8"/>
+          <rect x="822" y="232" width="190" height="80" rx="12" fill="#1b1440" stroke="#a888ff" stroke-width="1.8"/>
+          <rect x="716" y="388" width="306" height="120" rx="14" fill="#08324a" stroke="#00bceb" stroke-width="2"/>
+        </g>
+
+        <!-- NODE LABELS (crisp) -->
+        <g font-family="IBM Plex Sans, sans-serif" fill="#eaf5ff" text-anchor="middle">
+          <text x="703" y="82" font-size="13.5" font-weight="600">Microsoft Entra ID</text>
+          <text x="703" y="100" font-size="10.5" fill="#c3b6ff">identity</text>
+          <text x="857" y="82" font-size="13.5" font-weight="600">SaaS</text>
+          <text x="857" y="100" font-size="10.5" fill="#9fe9ff">O365 · Salesforce</text>
+          <text x="979" y="90" font-size="13" font-weight="600">Internet</text>
+
+          <text x="125" y="150" font-size="14" font-weight="600">Remote Users</text>
+          <text x="125" y="170" font-size="10.5" fill="#ffd79c">Zero Trust Access · VPN</text>
+
+          <text x="125" y="270" font-size="14" font-weight="600">Remote Branches</text>
+          <text x="125" y="290" font-size="10.5" fill="#a7f5da">Branch A – D</text>
+          <text x="125" y="312" font-size="10.5" fill="#a7f5da">on SD-WAN</text>
+
+          <text x="125" y="420" font-size="14" font-weight="600">Branch</text>
+          <text x="125" y="440" font-size="10.5" fill="#a7f5da">access switch · client PCs</text>
+          <text x="125" y="460" font-size="10.5" fill="#a7f5da">branch printer · overlay VPN</text>
+
+          <text x="518" y="156" font-size="17" font-weight="700" fill="#8fe9ff">SSE</text>
+          <text x="518" y="176" font-size="11" fill="#bfe9ff">Security Service Edge</text>
+
+          <text x="345" y="288" font-size="14" font-weight="700" fill="#8ff5cf">SD-WAN</text>
+          <text x="345" y="308" font-size="10.5" fill="#a7f5da">Network fabric</text>
+
+          <text x="600" y="286" font-size="14.5" font-weight="700" fill="#8fe9ff">Corp Enterprise</text>
+          <text x="600" y="306" font-size="10.5" fill="#bfe9ff">On-Prem / HQ</text>
+          <text x="600" y="326" font-size="10.5" fill="#bfe9ff">Head End Routers A / B · 4×10G LAG</text>
+
+          <text x="917" y="152" font-size="15" font-weight="700" fill="#c3b6ff">Azure</text>
+          <text x="917" y="172" font-size="10.5" fill="#c3b6ff">VM · K8s apps</text>
+          <text x="917" y="264" font-size="15" font-weight="700" fill="#c3b6ff">AWS</text>
+          <text x="917" y="284" font-size="10.5" fill="#c3b6ff">VM · K8s apps</text>
+
+          <text x="869" y="416" font-size="14.5" font-weight="700" fill="#8fe9ff">On-Premises Application Environment</text>
+          <text x="869" y="440" font-size="11" fill="#bfe9ff">Internal Web (VM) · HR Systems (K8s) · IR System</text>
+          <text x="869" y="462" font-size="10.5" fill="#7fb6d8">Kubernetes clusters · virtual machines</text>
+        </g>
+
+        <!-- LEGEND -->
+        <g font-family="IBM Plex Mono, monospace" font-size="10.5" fill="#9db8d6">
+          <line x1="34" y1="600" x2="70" y2="600" stroke="#00bceb" stroke-width="3"/>
+          <text x="78" y="604">Physical / 10G LAG</text>
+          <line x1="220" y1="600" x2="256" y2="600" stroke="#3ff0b0" stroke-width="2" stroke-dasharray="7 6"/>
+          <text x="264" y="604">VPN / overlay tunnel</text>
+          <line x1="420" y1="600" x2="456" y2="600" stroke="#a888ff" stroke-width="2" stroke-dasharray="2 5"/>
+          <text x="464" y="604">Identity / API</text>
+          <text x="600" y="604" fill="#5fd7ff">Neon reference — draw your solution on top of this network.</text>
+        </g>
+      </svg>
     </div>
-    <p class="sample-note">Remote branches and Zero Trust Access users reach the enterprise through <b>SD-WAN</b> and <b>SSE</b>; the corporate HQ (on-prem head-end routers) connects to the on-premises application environment and to <b>Azure</b> and <b>AWS</b> apps over cloud-exchange peering, with identity from <b>Microsoft Entra ID</b>. This is the network you're securing — draw your solution for each use case on top of it.</p>
+    <p class="sample-note">Remote branches and Zero Trust Access users reach the enterprise through <b>SD-WAN</b> and <b>SSE</b>; the corporate HQ (on-prem head-end routers) connects to the on-premises application environment and to <b>Azure</b> and <b>AWS</b> over cloud-exchange peering, with identity from <b>Microsoft Entra ID</b>. This is the network you're securing — draw your solution for each use case on top of it. <a href="reference-network.jpg" target="_blank" rel="noopener">View the detailed source diagram &rarr;</a></p>
   </section>
 
   <!-- ============ BUSINESS OBJECTIVES ============ -->


### PR DESCRIPTION
## What & why

Professional visual pass, per request.

- **Cisco brand colors** across all three pages (participant, proctor, leaderboard): Cisco Blue `#00BCEB`, midnight `#0D274D`, a deeper blue for text/links, and refreshed hero/top gradients — applied through the shared CSS variables so everything shifts consistently.
- **Neon reference diagram:** replaced the plain photo with a professional dark-theme **neon SVG** recreation of the customer architecture — glowing nodes, Cisco-blue core (SSE, Corp HQ head-end routers, on-prem apps), neon-green SD-WAN/branches, amber remote users, purple cloud (Entra ID / Azure / AWS), and a solid / dashed / dotted **link-type legend**. The original photo remains in the repo and is linked as "detailed source diagram."

## Verification
Playwright render — diagram screenshot reviewed for layout/legibility, no JS errors on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_