### PR TITLE
Open each use case as a dedicated full-screen page with persona playbook + time budget

### DIFF
--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -595,6 +595,26 @@
   .uc-submit{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-top:22px;padding-top:16px;border-top:1px dashed var(--line-soft)}
   .uc-substatus{font-family:"IBM Plex Mono",monospace;font-size:11.5px;margin-right:auto}
   #ucAddProd{margin-top:10px}
+  /* full-screen use-case view */
+  .uc-view{position:fixed;inset:0;z-index:250;background:#F3F6FA;display:flex;flex-direction:column}
+  .uc-view[hidden]{display:none}
+  body.uc-view-open{overflow:hidden}
+  .uc-view-top{display:flex;align-items:center;gap:14px;padding:12px 18px;background:var(--navy);color:#fff;box-shadow:0 2px 12px rgba(0,0,0,.25)}
+  .uc-back{display:inline-flex;align-items:center;gap:6px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.22);color:#fff;border-radius:9px;padding:8px 12px;font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;cursor:pointer}
+  .uc-back:hover{background:rgba(255,255,255,.22)}
+  .uc-back svg{width:15px;height:15px;stroke-width:2.4}
+  .uc-view-title{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:16px;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .uc-pace{font-family:"IBM Plex Mono",monospace;font-size:12.5px;font-weight:600;color:#bfe9ff;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.16);border-radius:20px;padding:6px 12px;white-space:nowrap}
+  .uc-pace.behind{color:#ffd0a3;border-color:rgba(226,137,31,.6);background:rgba(226,137,31,.18)}
+  .uc-pace.good{color:#b6f0d8;border-color:rgba(39,162,118,.6);background:rgba(39,162,118,.18)}
+  .uc-view-scroll{flex:1;overflow-y:auto;padding:20px 0 64px}
+  .uc-allot{background:#EAF6FB;border:1px solid #BEE3EA;border-left:4px solid var(--cyan-deep);border-radius:10px;padding:10px 14px;font-size:13px;color:#0a5560;margin:14px 0}
+  .uc-playbook{margin:0 0 18px}
+  .pb-card{border:1px solid var(--line);border-top:3px solid var(--pc,#7E8CA1);border-radius:11px;padding:11px 13px;background:var(--surface,#fff)}
+  .pb-card.you{box-shadow:0 0 0 2px var(--pc);background:#fbffff}
+  .pb-name{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:13.5px;color:var(--ink);margin-bottom:5px;display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+  .pb-you{font-family:"IBM Plex Mono",monospace;font-size:9px;font-weight:700;letter-spacing:.06em;color:#fff;background:var(--pc);border-radius:12px;padding:2px 7px}
+  .pb-does{font-size:12px;color:var(--ink-soft);line-height:1.45}
 
   /* --- persona "take your seat" login --- */
   .persona-btn{
@@ -1158,8 +1178,8 @@
       <span class="sec-no">WORKSPACE</span>
       <h2>Group response</h2>
     </div>
-    <p class="sec-sub">Your live worksheet for the selected use case. Everything is saved in this browser as you type; when the group agrees, attach your diagram and submit for scoring.</p>
-    <div id="ucWorkspace"><!-- built by the interactive engine from the selected use case --></div>
+    <p class="sec-sub">Click a use case above to open its <b>dedicated workspace</b> — the brief, the persona playbook (who does what), your time budget, and the answer tables, all in one focused view. Everything is saved in this browser as you type.</p>
+    <button type="button" class="st-btn go" id="ucOpenBtn" style="font-size:14px;padding:11px 18px">Open the selected use case &rarr;</button>
   </section>
 
   <div class="foot">
@@ -1167,6 +1187,18 @@
     <span class="tag">4 roles · 60 minutes · 5 use cases</span>
   </div>
 
+</div>
+
+<!-- ============ USE-CASE FULL-SCREEN VIEW ============ -->
+<div class="uc-view" id="ucView" hidden>
+  <div class="uc-view-top">
+    <button class="uc-back" id="ucBack" type="button"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M15 18l-6-6 6-6"/></svg>All use cases</button>
+    <span class="uc-view-title" id="ucViewTitle">Use Case</span>
+    <span class="uc-pace" id="ucPace"></span>
+  </div>
+  <div class="uc-view-scroll">
+    <div class="wrap"><div id="ucWorkspace"><!-- rendered per use case --></div></div>
+  </div>
 </div>
 
 <!-- ============ INTERACTIVE ENGINE ============ -->
@@ -1549,14 +1581,26 @@
         "Make sure your proposed solution addresses each customer requirement and pain point.",
         "Attach the diagram and submit for SME review and scoring."
       ],
-      productRows:6
+      productRows:6, minutes:18
     },
     { n:2, title:"Use Case 2", locked:true },
     { n:3, title:"Use Case 3", locked:true },
     { n:4, title:"Use Case 4", locked:true },
     { n:5, title:"Use Case 5", locked:true }
   ];
+  // Pace: 60 minutes; aim to bank at least this many. ~18 min each lets a team land 3.
+  var UC_ALLOT_MIN = 18, UC_TARGET = 3;
+  // What each seat does to complete a use case (highlighted for the current role).
+  var PLAYBOOK = [
+    { role:"conductor", name:"IT Director", color:"#E2891F", does:"Read the use case aloud, split the work, and watch the clock — drive a submission by ~"+18+" min so the team banks the next one." },
+    { role:"critic", name:"Digital Resiliency Officer", color:"#DB4A4A", does:"Pressure-test each product choice: does it truly address the pain point? What breaks it? Make sure every pain point is answered." },
+    { role:"architect", name:"Network Architect", color:"#0FA9BE", does:"Draw the topology with your proposed products on it — enforcement points, groups, and one traced flow — then attach it." },
+    { role:"scribe", name:"Network Security Engineer", color:"#27A276", does:"Fill the pain→product mapping and the products (how/why) tables, capture the 'why', and submit for the team." }
+  ];
   function ucByN(n){ for(var i=0;i<USE_CASES.length;i++){ if(USE_CASES[i].n===n) return USE_CASES[i]; } return null; }
+  function ucMinutes(uc){ return (uc && uc.minutes) || UC_ALLOT_MIN; }
+  function ucSubmittedCount(){ return Object.keys(ucSubmitted||{}).length; }
+  function ucElapsedSec(){ try{ if(typeof managed!=="undefined" && managed && typeof evElapsed==="function") return evElapsed(); }catch(e){} return (typeof elapsed==="number"?elapsed:0); }
   function ucTeamKey(){ return (persona && (persona.teamCode || (persona.team||"").trim().toLowerCase())) || "solo"; }
   function ucFieldKey(n, id){ return "ztds.uc."+n+"."+ucTeamKey()+"."+id; }
   function ucGet(n,id){ try{ return localStorage.getItem(ucFieldKey(n,id))||""; }catch(e){ return ""; } }
@@ -1604,9 +1648,7 @@
       card.addEventListener("click", function(){
         if(uc.locked){ toast("Use case "+uc.n+" — coming soon","This use case will be added soon. Complete Use Case 1 first.","phase"); return; }
         if(!ucIsUnlocked(uc.n)){ toast("Locked","Submit Use Case "+(uc.n-1)+" first — then this one unlocks.","fire"); return; }
-        ucSelected=uc.n; try{ localStorage.setItem("ztds.uc.selected", String(uc.n)); }catch(e){}
-        renderUcHub(); renderUcWorkspace();
-        var ws=document.getElementById("workspace"); if(ws) ws.scrollIntoView({behavior:"smooth",block:"start"});
+        openUseCase(uc.n);
       });
       list.appendChild(card);
     });
@@ -1672,6 +1714,10 @@
           '<div class="uc-col cyan"><div class="uc-col-h">Your tasks</div><ul>'+li(uc.tasks)+'</ul></div>'+
         '</div>'+
       '</div>'+
+      '<div class="uc-allot">⏱ <b>Suggested ~'+ucMinutes(uc)+' min</b> for this use case — aim to bank <b>'+UC_TARGET+'+ of 5</b> before 60:00. Submitting unlocks the next; keep it moving.</div>'+
+      '<div class="uc-playbook"><div class="uc-col-h" style="margin-bottom:9px">Persona playbook — who does what</div><div class="grid g4">'+
+        PLAYBOOK.map(function(pb){ var you=(persona&&persona.role===pb.role); return '<div class="pb-card'+(you?" you":"")+'" style="--pc:'+pb.color+'"><div class="pb-name">'+ucEsc(pb.name)+(you?' <span class="pb-you">YOU</span>':'')+'</div><div class="pb-does">'+ucEsc(pb.does)+'</div></div>'; }).join('')+
+      '</div></div>'+
       '<div class="uc-step"><div class="uc-step-h"><span class="uc-step-n">1</span>Pain point &rarr; product mapping</div>'+
         '<p class="uc-step-sub">For each customer pain point, name the product/feature you propose and how it addresses it.</p>'+
         '<div class="uc-table-wrap"><table class="uctab"><thead><tr><th>Customer pain point</th><th>Proposed product(s)</th><th>How it addresses / why</th></tr></thead><tbody>'+painRows+'</tbody></table></div>'+
@@ -1763,6 +1809,34 @@
       else toast("Use Case "+uc.n+" submitted","Sent to the proctor in "+fmt(total)+". Next use case unlocked — you can still edit and re-submit.","phase");
     });
   }
+
+  // ----- full-screen use-case view -----
+  function openUseCase(n){
+    ucSelected=n; try{ localStorage.setItem("ztds.uc.selected", String(n)); }catch(e){}
+    renderUcHub(); renderUcWorkspace();
+    var uc=ucByN(n);
+    var t=$("#ucViewTitle"); if(t) t.textContent = "Use Case "+n + (uc&&uc.title?(" — "+uc.title):"");
+    updateUcPace();
+    var v=$("#ucView"); if(v){ v.hidden=false; document.body.classList.add("uc-view-open"); v.scrollTop=0; var sc=v.querySelector(".uc-view-scroll"); if(sc) sc.scrollTop=0; }
+  }
+  function closeUseCase(){ var v=$("#ucView"); if(v) v.hidden=true; document.body.classList.remove("uc-view-open"); renderUcHub(); }
+  function updateUcPace(){
+    var el=$("#ucPace"); if(!el) return;
+    var sec=Math.max(0, Math.round(ucElapsedSec())), banked=ucSubmittedCount();
+    var mm=Math.floor(sec/60), ss=sec%60;
+    var due=Math.floor(sec/60/UC_ALLOT_MIN);                 // how many should be banked by now
+    var behind = banked < Math.min(due, UC_TARGET);
+    el.innerHTML='⏱ '+(mm<10?'0':'')+mm+':'+(ss<10?'0':'')+ss+' · <b>'+banked+'</b>/'+UC_TARGET+'+ banked'+(behind?' · pick up the pace':'');
+    el.className='uc-pace'+(behind?' behind':(banked>=UC_TARGET?' good':''));
+  }
+  var ucBackBtn=$("#ucBack"); if(ucBackBtn) ucBackBtn.addEventListener("click", closeUseCase);
+  var ucOpenBtn=$("#ucOpenBtn"); if(ucOpenBtn) ucOpenBtn.addEventListener("click", function(){
+    var uc=ucByN(ucSelected);
+    if(uc && !uc.locked && ucIsUnlocked(ucSelected)) openUseCase(ucSelected);
+    else openUseCase(1);
+  });
+  document.addEventListener("keydown", function(e){ if(e.key==="Escape"){ var v=$("#ucView"); if(v && !v.hidden) closeUseCase(); } });
+  setInterval(updateUcPace, 1000);
 
   // initial paint once all engine vars are assigned
   setTimeout(function(){ renderUcHub(); renderUcWorkspace(); }, 0);


### PR DESCRIPTION
## What & why

Per request: clicking a use case now opens it as its **own focused page**, shows **what each persona does**, and adds a **time budget** so teams pace to complete 3+.

- **Full-screen use-case view** — clicking a card (or "Open the selected use case") opens a dedicated view with a Cisco-navy top bar: **← All use cases** back button, the use-case title, and a **live pace badge** (`⏱ MM:SS · N/3+ banked`) that turns amber when the team is behind pace. Esc/Back returns to the hub; body scroll locks while open.
- **Time allotment** — a strip reads *"Suggested ~18 min for this use case — aim to bank 3+ of 5 before 60:00."* Pace math: ~18 min/use case, target 3; "behind" when banked < min(elapsed ÷ 18 min, 3).
- **Persona playbook** — a card per seat (IT Director / Digital Resiliency Officer / Network Architect / Network Security Engineer) describing what each does to complete the use case, with the **seated member's card marked YOU**.
- Then the brief, the pain→product and products tables, diagram upload, and submit — all in the one view.

## Verification (Playwright + screenshot)
Card opens the view with the correct title, pace badge, allotment strip, and 4-card playbook (YOU on the seated role — verified with an "architect" persona); both answer tables + submit present; Back closes and unlocks scroll. No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_