### PR TITLE
Rebrand proctor and leaderboard to "Zero Trust Access Design Clinic"

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Leaderboard — Zero Trust Agentic Design Sprint</title>
+<title>Leaderboard — Zero Trust Access Design Clinic</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -61,7 +61,7 @@
 <header class="top">
   <div class="wrap top-in">
     <div>
-      <span class="eyebrow">Zero Trust Agentic Design Sprint</span>
+      <span class="eyebrow">Zero Trust Access Design Clinic</span>
       <h1>🏆 Leaderboard</h1>
       <div class="sub">Team scores — each use case is 100 pts (up to 5). Ranked by total. Updates live.</div>
     </div>

--- a/proctor.html
+++ b/proctor.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Proctor · Live Roster — Zero Trust Agentic Design Sprint</title>
+<title>Proctor · Live Roster — Zero Trust Access Design Clinic</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -227,7 +227,7 @@
 <header class="top">
   <div class="wrap top-in">
     <div>
-      <span class="eyebrow">Zero Trust Agentic Design Sprint · Facilitator</span>
+      <span class="eyebrow">Zero Trust Access Design Clinic · Facilitator</span>
       <h1>Live Team Roster</h1>
       <div class="sub">Everyone who has taken a seat, grouped by team — updates in real time.</div>
     </div>
@@ -590,7 +590,7 @@
       '@media print{.toolbar{display:none}}'+
       '</style></head><body>'+
       '<div class="toolbar"><button onclick="window.print()">Print / Save as PDF</button></div>'+
-      '<h1>Zero Trust Agentic Design Sprint — Participant Report</h1>'+
+      '<h1>Zero Trust Access Design Clinic — Participant Report</h1>'+
       '<div class="meta">Room: <b>'+esc(ROOM)+'</b> &nbsp;·&nbsp; Generated: '+esc(fmtDateTime(Date.now()))+'</div>'+
       '<div class="cards">'+
         '<div class="card"><b>'+latest.length+'</b><small>Participants</small></div>'+


### PR DESCRIPTION
## What & why

Matches the participant page rename. Updates `proctor.html` and `leaderboard.html`:

- Browser `<title>` on both.
- Header eyebrows ("… · Facilitator" / leaderboard eyebrow).
- The printable **participant report** heading on the proctor.

No "Design Sprint" / "Agentic Design Sprint" strings remain on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_