### PR TITLE
Store diagram photos in Firebase Storage (URL in Firestore) for clean scaling

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -85,7 +85,32 @@ Allows registering/submitting/scoring/controlling and reading; blocks client-sid
 add features you must re-publish this full block** — if an older version is live, submissions,
 scores, or the shared "Start event" clock will be rejected.
 
-### 2d. (Optional) Restrict the API key — defense-in-depth  ⬜
+### 2d. (Recommended for scale) Enable Storage for diagram photos  ⬜
+Diagrams are uploaded to **Firebase Storage** and only their short download URL is stored in
+Firestore — this keeps large images out of the database (important at ~300 participants). If
+Storage isn't enabled, the app **falls back** to embedding the image inline (still works, just
+heavier), so this step is optional but recommended.
+
+- Console → **Build → Storage → Get started** (accept the default bucket, same location as Firestore).
+- Storage → **Rules** tab → paste and **Publish**:
+
+```
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /diagrams/{allPaths=**} {
+      allow read: if true;
+      allow write: if request.resource.size < 6 * 1024 * 1024
+        && request.resource.contentType.matches('image/.*');
+    }
+  }
+}
+```
+
+Allows uploading/reading diagram images (capped at 6 MB, images only) under `diagrams/…`;
+everything else stays locked. The `storageBucket` value is already in `firebase-config.js`.
+
+### 2e. (Optional) Restrict the API key — defense-in-depth  ⬜
 Google Cloud Console → **APIs & Services → Credentials** → project `design-clinic-58ad0` →
 open **"Browser key (auto created by Firebase)"**:
 

--- a/ai-eval-worker.js
+++ b/ai-eval-worker.js
@@ -55,8 +55,8 @@ export default {
       "criterion. Always respond by calling the submit_score tool.";
 
     const content = [{ type: "text", text: buildUserText(body, rubric) }];
-    const img = parseDataUrl(body && body.response && body.response.diagram);
-    if (img) content.push({ type: "image", source: { type: "base64", media_type: img.mime, data: img.data } });
+    const blk = imageBlock(body && body.response && body.response.diagram);
+    if (blk) content.push(blk);
 
     const tool = {
       name: "submit_score",
@@ -137,7 +137,7 @@ function buildUserText(body, rubric) {
   (resp.painMap || []).forEach(function (r) { lines.push("  - PAIN: " + (r.pain || "") + " | PRODUCT: " + (r.product || "—") + " | HOW/WHY: " + (r.note || "—")); });
   lines.push("Products proposed (name / how / why):");
   (resp.products || []).forEach(function (r) { lines.push("  - " + (r.product || "—") + " | " + (r.how || "—") + " | " + (r.why || "—")); });
-  lines.push("Diagram attached: " + (parseDataUrl(resp.diagram) ? "yes (see image)" : "no"));
+  lines.push("Diagram attached: " + (imageBlock(resp.diagram) ? "yes (see image)" : "no"));
   lines.push("");
   lines.push("Score the team's response against the reference using the rubric. Call submit_score.");
   return lines.join("\n");
@@ -150,6 +150,14 @@ function parseDataUrl(u) {
   const mime = m[1];
   if (["image/jpeg", "image/png", "image/gif", "image/webp"].indexOf(mime) < 0) return null;
   return { mime: mime, data: m[2] };
+}
+
+// Build an Anthropic image block from either a Storage/HTTP URL or an inline data URL.
+function imageBlock(u) {
+  if (typeof u !== "string") return null;
+  if (u.indexOf("http") === 0) return { type: "image", source: { type: "url", url: u } };
+  const img = parseDataUrl(u);
+  return img ? { type: "image", source: { type: "base64", media_type: img.mime, data: img.data } } : null;
 }
 
 function clamp(v, max) { v = parseInt(v, 10); if (isNaN(v) || v < 0) v = 0; if (v > max) v = max; return v; }

--- a/proctor.html
+++ b/proctor.html
@@ -632,8 +632,9 @@
     $("#emMeta").style.color = (sol&&sol.late) ? "var(--red)" : "";
     // ----- team response -----
     var parts=[];
-    if(sol && typeof sol.diagram==="string" && sol.diagram.indexOf("data:image")===0){
-      parts.push('<div class="em-field"><div class="k">Proposed diagram</div><img class="em-diag" src="'+sol.diagram+'" alt="team diagram"></div>');
+    var dg=(sol&&typeof sol.diagram==="string")?sol.diagram:"";
+    if(dg && (dg.indexOf("data:image")===0 || dg.indexOf("http")===0)){
+      parts.push('<div class="em-field"><div class="k">Proposed diagram</div><img class="em-diag" src="'+esc(dg)+'" alt="team diagram"></div>');
     } else {
       parts.push('<div class="em-field"><div class="k">Proposed diagram</div><div class="v empty">— no diagram attached —</div></div>');
     }
@@ -696,14 +697,20 @@
     (resp.painMap||[]).forEach(function(x){ L.push("  - PAIN: "+(x.pain||"")+" | PRODUCT: "+(x.product||"—")+" | HOW/WHY: "+(x.note||"—")); });
     L.push("Products proposed (name / how / why):");
     (resp.products||[]).forEach(function(x){ L.push("  - "+(x.product||"—")+" | "+(x.how||"—")+" | "+(x.why||"—")); });
-    L.push("Diagram attached: "+(aiParseDataUrl(resp.diagram)?"yes (see image)":"no"),"");
+    L.push("Diagram attached: "+(aiImageBlock(resp.diagram)?"yes (see image)":"no"),"");
     L.push("Score the team's response against the reference using the rubric. Call submit_score.");
     return L.join("\n");
   }
+  function aiImageBlock(u){
+    if(typeof u!=="string") return null;
+    if(u.indexOf("http")===0) return {type:"image",source:{type:"url",url:u}};
+    var img=aiParseDataUrl(u);
+    return img ? {type:"image",source:{type:"base64",media_type:img.mime,data:img.data}} : null;
+  }
   function aiAnthropicBody(p){
     var r=aiRubric(p), content=[{type:"text",text:aiUserText(p)}];
-    var img=aiParseDataUrl(p.response&&p.response.diagram);
-    if(img) content.push({type:"image",source:{type:"base64",media_type:img.mime,data:img.data}});
+    var blk=aiImageBlock(p.response&&p.response.diagram);
+    if(blk) content.push(blk);
     var tool={ name:"submit_score", description:"Return the rubric scores and a short rationale.",
       input_schema:{ type:"object", properties:{
         c1:{type:"integer",minimum:0,maximum:r.c1.max}, c2:{type:"integer",minimum:0,maximum:r.c2.max},

--- a/roster.js
+++ b/roster.js
@@ -43,7 +43,9 @@
         var l = { coll: coll, room: room, cb: cb }; listeners.push(l);
         var iv = setInterval(function () { cb(readAll(coll, room)); }, 2000);
         return function () { clearInterval(iv); var idx = listeners.indexOf(l); if (idx >= 0) listeners.splice(idx, 1); };
-      }
+      },
+      // No object storage in single-device mode — callers fall back to inline base64.
+      uploadDiagram: function () { return Promise.reject(new Error("no storage in local mode")); }
     };
   }
 
@@ -58,6 +60,14 @@
           watch: function (coll, room, cb) {
             var q = fs.query(fs.collection(db, coll), fs.where("room", "==", room));
             return fs.onSnapshot(q, function (snap) { var d = []; snap.forEach(function (docSnap) { d.push(docSnap.data()); }); cb(d); });
+          },
+          // Upload a diagram (data URL) to Firebase Storage; resolves to a public download URL.
+          // Keeps the big image bytes OUT of Firestore — only the short URL is stored.
+          uploadDiagram: function (path, dataUrl) {
+            return import(SDK + "firebase-storage.js").then(function (st) {
+              var ref = st.ref(st.getStorage(app), path);
+              return st.uploadString(ref, dataUrl, "data_url").then(function () { return st.getDownloadURL(ref); });
+            });
           }
         };
       });

--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -1693,12 +1693,19 @@
     else { try{ diagUrl=localStorage.getItem(diagKey)||null; }catch(e){} }
     var diagInput=$("#ucDiag"), diagThumb=$("#ucDiagThumb"), diagClear=$("#ucDiagClear");
     function showDiag(){ if(diagUrl){ diagThumb.src=diagUrl; diagThumb.hidden=false; diagClear.hidden=false; } else { diagThumb.removeAttribute("src"); diagThumb.hidden=true; diagClear.hidden=true; } }
+    function shareDiag(val){ diagUrl=val; try{ localStorage.setItem(diagKey,val); }catch(e){} showDiag(); pushDraftDiagram(uc.n, val); }
     diagInput.addEventListener("change", function(){
       var f=diagInput.files && diagInput.files[0]; if(!f) return;
       ucLoadDiagram(f, function(url){
         if(!url){ toast("Couldn't read image","Try a different photo (JPG/PNG).","fire"); return; }
         diagUrl=url; try{ localStorage.setItem(diagKey,url); }catch(e){}
-        showDiag(); pushDraftDiagram(uc.n, url); toast("Diagram attached","Shared with your team; sent to the proctor when you submit.","phase");
+        showDiag(); toast("Diagram attached","Shared with your team; sent to the proctor when you submit.","phase");
+        // Move the bytes to Firebase Storage and share the short URL (keeps big images out of
+        // Firestore). Falls back to the inline image if Storage isn't available.
+        if(roster && roster.uploadDiagram && ROOM){
+          var path="diagrams/"+ROOM+"/"+ucTeamKey()+"/uc"+uc.n+".jpg";
+          roster.uploadDiagram(path, url).then(function(remote){ shareDiag(remote||url); }, function(){ shareDiag(url); });
+        } else { shareDiag(url); }
       });
       diagInput.value="";
     });


### PR DESCRIPTION
## What & why

Diagrams were embedded as **base64 inside Firestore docs** — heavy at ~300 participants and close to the 1 MB/doc limit. Now the image bytes go to **Firebase Storage** and only the short **download URL** is stored in Firestore. There's a **graceful fallback to inline base64** when Storage isn't enabled, so nothing breaks either way.

## Changes

- **`roster.js`** — add `uploadDiagram()` to the Firebase adapter (dynamic `firebase-storage` import → `uploadString(data_url)` → `getDownloadURL`); the local adapter rejects so callers fall back to inline.
- **Participant** — on attach, upload to `diagrams/<room>/<team>/uc<n>.jpg` and share the returned URL with the team (live draft) and on submit; inline base64 only if the upload fails.
- **Proctor eval + AI eval** — accept a `data:` **or** `http(s)` diagram. AI sends the image via Anthropic's **URL image source** when it's a Storage URL (both the serverless worker and the proctor's browser-key path).
- **`SETUP.md`** — new "Enable Storage for diagram photos" step with Storage security rules (images only, ≤6 MB, under `diagrams/…`).

## Verification (Playwright)

- **Local mode** (no Storage): attach falls back to **inline base64**, thumbnail + draft both `data:image` — no errors.
- **Proctor** renders an **https Storage-URL** diagram in the eval modal.
- **Worker** unit test still green (image block, clamping, CORS, error paths).

## To enable (optional but recommended for scale)

Firebase Console → **Build → Storage → Get started**, then publish the Storage rules from `SETUP.md` §2d. Until then, diagrams keep working inline. The `storageBucket` is already in `firebase-config.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_