### PR TITLE
Show use cases as square image tiles with clear sequential unlock

### DIFF
--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -567,6 +567,27 @@
   .uc-card .uc-tag{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-faint)}
   .uc-card .uc-state{font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;color:var(--ink-soft);white-space:nowrap}
   .uc-card.done .uc-state{color:var(--green)}
+  /* square image tiles */
+  .uc-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:16px}
+  .uc-tile{position:relative;display:flex;flex-direction:column;text-align:left;padding:0;border:1px solid var(--line);border-radius:16px;overflow:hidden;background:var(--surface);cursor:pointer;box-shadow:var(--shadow);transition:transform .12s ease,box-shadow .15s}
+  .uc-tile:hover{transform:translateY(-3px);box-shadow:0 18px 36px -18px rgba(14,26,43,.55)}
+  .uc-tile.locked,.uc-tile.soon{cursor:not-allowed}
+  .uc-tile.open{border-color:var(--cyan)}
+  .ut-art{position:relative;aspect-ratio:16/10;display:flex;align-items:center;justify-content:center}
+  .ut-art svg{width:62px;height:62px;stroke:#fff;fill:none;stroke-linecap:round;stroke-linejoin:round;opacity:.96;filter:drop-shadow(0 4px 10px rgba(0,0,0,.25))}
+  .uc-tile.locked .ut-art,.uc-tile.soon .ut-art{filter:grayscale(.4) brightness(.92)}
+  .uc-tile.locked .ut-art svg,.uc-tile.soon .ut-art svg{opacity:.5}
+  .ut-lock,.ut-check{position:absolute;top:10px;right:10px;width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:15px}
+  .ut-lock{background:rgba(6,20,44,.42);color:#fff}
+  .ut-check{background:var(--green);color:#fff;font-weight:800}
+  .ut-flag{position:absolute;top:10px;left:10px;font-family:"IBM Plex Mono",monospace;font-size:9.5px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:#062038;background:#8fe9ff;border-radius:20px;padding:3px 9px;box-shadow:0 3px 10px rgba(0,0,0,.28)}
+  .ut-body{padding:12px 14px 14px}
+  .ut-n{font-family:"IBM Plex Mono",monospace;font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--cyan-deep)}
+  .uc-tile.done .ut-n{color:var(--green)}
+  .uc-tile.locked .ut-n,.uc-tile.soon .ut-n{color:var(--ink-faint)}
+  .ut-t{font-family:"Chakra Petch",sans-serif;font-weight:700;font-size:15px;color:var(--ink);margin:3px 0 6px;line-height:1.15}
+  .ut-state{font-family:"IBM Plex Mono",monospace;font-size:10.5px;font-weight:600;color:var(--ink-soft);line-height:1.4}
+  .uc-tile.done .ut-state{color:var(--green)}
   .uc-empty{padding:26px;text-align:center;color:var(--ink-soft);background:#F6F9FC;border:1px dashed var(--line);border-radius:12px}
   .uc-empty h3{margin:0 0 6px;color:var(--ink)}
   .uc-brief{background:#F7FAFD;border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin-bottom:18px}
@@ -1029,8 +1050,8 @@
       <span class="sec-no">USE CASES</span>
       <h2>Five use cases · solve in order</h2>
     </div>
-    <p class="sec-sub">Work them top to bottom. Complete a use case, submit your group response for scoring, and the next one unlocks. Do as many as you can before the clock runs out — each is scored on the leaderboard.</p>
-    <div class="uc-list" id="ucList"><!-- built by the interactive engine --></div>
+    <p class="sec-sub"><b>Solve them in order — Use Case 1 first.</b> Tap a tile to open it. When you submit a use case, the next one <b>unlocks</b> (locked tiles show 🔒). Do as many as you can before the clock runs out — each is scored on the leaderboard.</p>
+    <div class="uc-list" id="ucList"><!-- tiles built by the interactive engine --></div>
   </section>
 
   <!-- ============ WHAT GOOD LOOKS LIKE (sample) ============ -->
@@ -1550,27 +1571,49 @@
     if(v && !v.hidden && ucLiveApply) ucLiveApply();          // push shared changes onto the open sheet
   }
 
-  // ----- hub (list of 5 use case cards) -----
+  // ----- per-use-case tile artwork (inline SVG icons) -----
+  function ucArt(n){
+    var art={
+      1:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M12 3l7 3v5c0 4.4-3 7.6-7 8.7-4-1.1-7-4.3-7-8.7V6z"/><path d="M9 12l2 2 4-4"/></svg>',
+      2:'<svg viewBox="0 0 24 24" stroke-width="1.6"><circle cx="12" cy="8" r="3.2"/><path d="M5.5 20a6.5 6.5 0 0113 0"/><path d="M18 3l1.4 2.6L22 7l-2.6 1.4L18 11l-1.4-2.6L14 7l2.6-1.4z"/></svg>',
+      3:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M7 18a4 4 0 01-.5-8A5.5 5.5 0 0117 8.5 3.8 3.8 0 0117 18z"/><rect x="10" y="13" width="5" height="4.5" rx="1"/><path d="M11 13v-1a1.5 1.5 0 013 0v1"/></svg>',
+      4:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M3 12h3l2.5 6 4-13 2.5 9 1.5-2H21"/></svg>',
+      5:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M6 21V4"/><path d="M6 4h11l-2 3 2 3H6"/><path d="M4 21h4"/></svg>'
+    };
+    return art[n]||art[5];
+  }
+  // ----- hub (grid of 5 square use-case tiles) -----
   function renderUcHub(){
     var list=$("#ucList"); if(!list) return;
+    // "Start here" = the first available, not-yet-submitted use case
+    var startN=0;
+    for(var i=0;i<USE_CASES.length;i++){ var u=USE_CASES[i]; if(!u.locked && ucIsUnlocked(u.n) && !ucIsSubmitted(u.n)){ startN=u.n; break; } }
     list.innerHTML="";
     USE_CASES.forEach(function(uc){
       var unlocked = ucIsUnlocked(uc.n) && !uc.locked;
       var submitted = ucIsSubmitted(uc.n);
-      var card=document.createElement("button");
-      card.type="button";
-      card.className="uc-card"+(uc.n===ucSelected?" sel":"")+(uc.locked?" soon":"")+(!unlocked?" locked":"")+(submitted?" done":"");
-      var state = uc.locked ? "Coming soon" : (submitted ? "Submitted ✓" : (unlocked ? (uc.n===ucSelected?"Selected":"Open") : "Locked"));
-      card.innerHTML =
-        '<span class="uc-n">'+uc.n+'</span>'+
-        '<span class="uc-mid"><span class="uc-t">'+ucEsc(uc.title)+'</span>'+(uc.tag?'<span class="uc-tag">'+ucEsc(uc.tag)+'</span>':'')+'</span>'+
-        '<span class="uc-state">'+state+'</span>';
-      card.addEventListener("click", function(){
-        if(uc.locked){ toast("Use case "+uc.n+" — coming soon","This use case will be added soon. Complete Use Case 1 first.","phase"); return; }
-        if(!ucIsUnlocked(uc.n)){ toast("Locked","Submit Use Case "+(uc.n-1)+" first — then this one unlocks.","fire"); return; }
+      var g = submitted ? "#1f8a63,#27A276" : uc.locked ? "#5b6b81,#8291a6" : unlocked ? "#0a5a99,#00BCEB" : "#5b6b81,#8291a6";
+      var stateCls = uc.locked ? "soon" : submitted ? "done" : unlocked ? "open" : "locked";
+      var badge = uc.locked ? "Coming soon" : submitted ? "Submitted" : unlocked ? "Open →" : "Locked";
+      var note = uc.locked ? "Added soon" : (!unlocked ? ("Submit Use Case "+(uc.n-1)+" first") : (submitted ? "Tap to review / re-submit" : "Tap to start"));
+      var corner = submitted ? '<div class="ut-check">✓</div>' : ((!unlocked)?'<div class="ut-lock">🔒</div>':'');
+      var flag = (uc.n===startN) ? '<div class="ut-flag">Start here</div>' : '';
+      var tile=document.createElement("button");
+      tile.type="button";
+      tile.className="uc-tile "+stateCls;
+      tile.innerHTML =
+        '<div class="ut-art" style="background:linear-gradient(135deg,'+g+')">'+ucArt(uc.n)+corner+flag+'</div>'+
+        '<div class="ut-body">'+
+          '<div class="ut-n">Use Case '+uc.n+'</div>'+
+          '<div class="ut-t">'+ucEsc(uc.title)+'</div>'+
+          '<div class="ut-state">'+badge+' · '+note+'</div>'+
+        '</div>';
+      tile.addEventListener("click", function(){
+        if(uc.locked){ toast("Use case "+uc.n+" — coming soon","Complete the earlier use cases first; this one is added soon.","phase"); return; }
+        if(!ucIsUnlocked(uc.n)){ toast("Locked","Submit Use Case "+(uc.n-1)+" first — then Use Case "+uc.n+" unlocks.","fire"); return; }
         openUseCase(uc.n);
       });
-      list.appendChild(card);
+      list.appendChild(tile);
     });
   }
 


### PR DESCRIPTION
## What & why

Per request: embed the use cases into the main page as **square buttons with a visual**, tap to open the use-case page, with clear direction that **Use Case 1 must be done first** and each unlocks the next.

- The vertical list is now a **responsive grid of square tiles**, each with a themed inline-SVG illustration on a gradient.
- **Use Case 1** is a bright Cisco-blue tile with a **"Start here"** flag; tapping it opens its page (the full-screen use-case view). Same for any unlocked tile.
- **Locked tiles** are greyed with a **🔒 badge** and read *"Submit Use Case N‑1 first"*; placeholders (2–5) show *"Coming soon"*. **Submitted** tiles turn green with a ✓ and *"Tap to review / re-submit"*.
- **"Start here"** marks the first available, not-yet-submitted use case, so the order is unmistakable.
- Section copy now states **"Solve them in order — Use Case 1 first."** Submitting a use case unlocks the next (existing sequential gating, unchanged).

## Verification (Playwright + screenshot)
5 tiles render with art; "Start here" on UC1; 4 locked; tapping UC1 opens its page; tapping a locked tile does **not** open (shows a toast). No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_