### PR TITLE
Let the proctor set their own passcode (self-service, privacy-preserving)

### DIFF
--- a/proctor.html
+++ b/proctor.html
@@ -272,6 +272,7 @@
     <span class="room">room:&nbsp;<input id="roomInput" type="text" spellcheck="false"><button class="btn" id="roomGo">Switch</button></span>
     <span class="filter">🔎&nbsp;<input id="filterInput" type="text" placeholder="Filter name / email / team / role" spellcheck="false"></span>
     <span class="spacer"></span>
+    <button class="btn" id="btnPasscode" title="Set your own proctor passcode"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="4" y="11" width="16" height="9" rx="2"/><path d="M8 11V7a4 4 0 018 0v4"/><circle cx="12" cy="15.5" r="1.4"/></svg>Passcode</button>
     <button class="btn" id="btnLock" title="Lock the console (require the passcode again)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="4" y="11" width="16" height="9" rx="2"/><path d="M8 11V7a4 4 0 018 0v4"/></svg>Lock</button>
     <button class="btn" id="btnAiKey" title="Use your own Anthropic key for AI scoring (stored only in this browser)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="8" cy="15" r="4"/><path d="M10.8 12.2L20 3m-4 0l3 3m-6 3l3 3"/></svg>AI key</button>
     <button class="btn" id="btnAiTest" title="Check AI evaluation works before a session"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 3a9 9 0 100 18 9 9 0 000-18z"/><path d="M12 8v4l3 2"/></svg>Test AI</button>
@@ -292,6 +293,7 @@
       <span id="aiKeyStatus"></span>
     </div>
   </div>
+  <div class="notice" id="pcNotice" hidden></div>
   <div class="notice" id="aiTestNotice" hidden></div>
   <div class="notice err" id="ruleNotice" hidden>
     <b>Firestore rejected the write (<code id="ruleCode">permission-denied</code>).</b>
@@ -590,6 +592,23 @@
   });
   $("#btnRefresh").addEventListener("click", function(){ location.reload(); });
   (function(){ var lk=$("#btnLock"); if(!lk) return; if(!(window.PROCTOR_PASSCODE_SHA256||"").trim()){ lk.hidden=true; } else { lk.addEventListener("click", lockProctor); } })();
+  // Set-your-own-passcode helper: hashes the chosen passcode in the browser and shows the
+  // config line to apply. The passcode itself never leaves this page — only its hash.
+  $("#btnPasscode").addEventListener("click", function(){
+    var n=$("#pcNotice");
+    if(!(window.crypto && crypto.subtle)){ n.className="notice err"; n.innerHTML="This browser can't generate the passcode code — open the page over HTTPS."; n.hidden=false; return; }
+    var np=(prompt("Choose a new proctor passcode.\n\nYou'll get a short code to send — your passcode itself is never shown or sent.")||"").trim();
+    if(!np) return;
+    crypto.subtle.digest("SHA-256", new TextEncoder().encode(np)).then(function(buf){
+      var hex=Array.prototype.map.call(new Uint8Array(buf), function(x){ return ("0"+x.toString(16)).slice(-2); }).join("");
+      n.className="notice ok";
+      n.innerHTML='<b>New passcode ready.</b> To make it live, this one line has to go into <code>firebase-config.js</code> and be pushed. '+
+        'It reveals nothing about your passcode — copy it and send it to whoever manages the site (or paste here in chat):'+
+        '<code style="display:block;margin-top:9px;word-break:break-all;user-select:all">window.PROCTOR_PASSCODE_SHA256 = "'+hex+'";</code>'+
+        '<span style="display:block;margin-top:8px;color:var(--ink-faint)">Until it’s pushed, the current passcode still applies. Remember your new passcode — it can’t be recovered from the code.</span>';
+      n.hidden=false; try{ n.scrollIntoView({behavior:"smooth",block:"center"}); }catch(e){}
+    }).catch(function(){ n.className="notice err"; n.innerHTML="Couldn’t generate the code — try again."; n.hidden=false; });
+  });
   $("#roomGo").addEventListener("click", function(){
     var v = ($("#roomInput").value||"").trim() || "default";
     location.search = "?room="+encodeURIComponent(v);


### PR DESCRIPTION
## What & why

So you can pick your own proctor passcode without editing files or telling anyone the passcode.

- New **Passcode** button on the proctor console: prompts for a new passcode, hashes it in the browser (SHA-256), and shows the exact `window.PROCTOR_PASSCODE_SHA256 = "…";` line to apply.
- The passcode itself **never leaves the page** — only its irreversible hash. You share just that one line to make it live.

## Verification (Playwright, localhost for Web Crypto)
Entering a chosen passcode produces exactly its SHA-256 hash in the config line; the notice renders; no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_