### PR TITLE
Add a "What good looks like" button in each use case

### DIFF
--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -853,6 +853,16 @@
   .diag-lightbox img{max-width:96vw;max-height:88vh;object-fit:contain;border-radius:8px;box-shadow:0 24px 70px rgba(0,0,0,.65)}
   .diag-lightbox .dl-cap{position:absolute;bottom:20px;left:50%;transform:translateX(-50%);color:var(--ink-soft);font-size:13px;background:rgba(6,23,46,.85);border:1px solid var(--line);border-radius:20px;padding:6px 14px;white-space:nowrap}
   .diag-lightbox .dl-close{position:absolute;top:16px;right:20px;width:40px;height:40px;border-radius:50%;border:1px solid var(--line);background:rgba(6,23,46,.85);color:var(--ink);font-size:22px;line-height:1;cursor:pointer}
+
+  /* ---- "What good looks like" sample button + modal ---- */
+  .sample-btn{border-color:rgba(240,166,60,.5) !important;color:var(--amber) !important}
+  .sample-btn:hover{background:rgba(240,166,60,.12) !important;border-color:var(--amber) !important}
+  .sample-modal{position:fixed;inset:0;z-index:500;display:flex;align-items:center;justify-content:center;padding:20px;background:rgba(8,18,34,.78);backdrop-filter:blur(3px)}
+  .sample-modal .sm-card{position:relative;width:min(720px,100%);max-height:90vh;overflow:auto;background:var(--surface);border:1px solid var(--line);border-top:4px solid var(--amber);border-radius:18px;padding:26px 26px 22px;box-shadow:0 30px 70px -20px rgba(0,0,0,.6);animation:rise .4s cubic-bezier(.2,.7,.3,1) both}
+  .sample-modal .sm-close{position:absolute;top:14px;right:16px;border:none;background:transparent;font-size:26px;line-height:1;color:var(--ink-faint);cursor:pointer}
+  .sample-modal .sm-close:hover{color:var(--ink)}
+  .sample-modal .sm-title{font-size:24px;font-weight:700;margin:6px 0 8px}
+  .sample-modal .sm-sub{font-size:13.5px;color:var(--ink-soft);margin-bottom:16px;line-height:1.6}
 </style>
 </head>
 <body>
@@ -1639,6 +1649,36 @@
     document.body.appendChild(lb);
   }
 
+  // ----- "What good looks like" sample (opened from a button in each use case) -----
+  var SAMPLE_HTML =
+    '<span class="sample-tag">Example scenario · not one of your use cases</span>'+
+    '<p class="sample-note">Customer pain: <i>"Guests and IoT cameras share the same VLAN, so a compromised camera can reach guest laptops — and we\'ve no budget for more firewalls."</i></p>'+
+    '<div class="sample-grid">'+
+      '<div class="uc-step-h" style="font-size:15px;margin-bottom:8px"><span class="uc-step-n">1</span>Pain point &rarr; product mapping</div>'+
+      '<div class="uc-table-wrap"><table class="uctab"><thead><tr><th>Customer pain point</th><th>Proposed product(s)</th><th>How it addresses / why</th></tr></thead><tbody>'+
+        '<tr><td class="pp">IoT and Guest share a VLAN; a hacked camera can reach guests</td><td>Cisco ISE + TrustSec SGTs</td><td>Profile each device at onboarding, tag <b>IOT</b> and <b>Guest</b> groups, and enforce an SGACL that denies IOT&#8596;Guest — on the existing switches.</td></tr>'+
+        '<tr><td class="pp">No budget for more firewalls to segment</td><td>TrustSec SGACL enforcement</td><td>Group-to-group policy is enforced <b>inline</b> on the Catalyst switches you already own — no new firewall to buy or cable.</td></tr>'+
+      '</tbody></table></div>'+
+      '<div class="uc-step-h" style="font-size:15px;margin:18px 0 8px"><span class="uc-step-n">2</span>Products proposed</div>'+
+      '<div class="uc-table-wrap"><table class="uctab"><thead><tr><th>Product / feature</th><th>Description / how</th><th>Why / differentiator</th></tr></thead><tbody>'+
+        '<tr><td>Cisco ISE</td><td>802.1X / MAB authenticate and profile every endpoint, then assign a group (SGT).</td><td>One policy source of truth; scales without per-subnet ACLs.</td></tr>'+
+        '<tr><td>TrustSec SGACL</td><td>Group-to-group allow/deny enforced inline on Catalyst switches.</td><td>Topology-independent; far fewer rules than IP ACLs (Cisco differentiator).</td></tr>'+
+      '</tbody></table></div>'+
+      '<div class="callout" style="margin-top:16px"><b>A strong diagram</b> labels every group, marks the <b>enforcement point</b> (where the SGACL/firewall sits), and traces <b>one flow end-to-end</b> (e.g. camera &rarr; denied &rarr; guest). Legible beats pretty.</div>'+
+    '</div>';
+  function openSampleModal(){
+    var m=document.createElement("div"); m.className="sample-modal"; m.setAttribute("role","dialog"); m.setAttribute("aria-modal","true"); m.setAttribute("aria-label",'What good looks like');
+    m.innerHTML='<div class="sm-card"><button class="sm-close" aria-label="Close">&times;</button>'+
+      '<div class="pm-eyebrow">Calibrate</div><h2 class="sm-title">What &ldquo;good&rdquo; looks like</h2>'+
+      '<p class="sm-sub">A short, <b>illustrative</b> example on a <b>different</b> scenario — use it to calibrate depth and format, not to copy. Strong answers name a specific product, say <b>how</b> it works in one line, and say <b>why</b> it fits (a Cisco differentiator earns extra).</p>'+
+      SAMPLE_HTML+'</div>';
+    function close(){ if(m.parentNode) m.parentNode.removeChild(m); document.removeEventListener("keydown",onKey); }
+    function onKey(e){ if(e.key==="Escape") close(); }
+    m.addEventListener("click",function(e){ if(e.target===m || (e.target.classList && e.target.classList.contains("sm-close"))) close(); });
+    document.addEventListener("keydown",onKey);
+    document.body.appendChild(m);
+  }
+
   // ----- workspace (active use case) -----
   function renderUcWorkspace(){
     var host=$("#ucWorkspace"); if(!host) return;
@@ -1683,6 +1723,7 @@
         PLAYBOOK.map(function(pb){ var you=(persona&&persona.role===pb.role); return '<div class="pb-card'+(you?" you":"")+'" style="--pc:'+pb.color+'"><div class="pb-name">'+ucEsc(pb.name)+(you?' <span class="pb-you">YOU</span>':'')+'</div><div class="pb-does">'+ucEsc(pb.does)+'</div></div>'; }).join('')+
       '</div></div>'+
       '<div class="uc-live" id="ucLive"></div>'+
+      '<button type="button" class="st-btn sample-btn" id="ucSampleBtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 18h6"/><path d="M10 21h4"/><path d="M12 3a6 6 0 00-3.8 10.6c.6.5 1 1.2 1.05 2H14.75c.05-.8.45-1.5 1.05-2A6 6 0 0012 3z"/></svg>See what &ldquo;good&rdquo; looks like</button>'+
       '<div class="uc-step"><div class="uc-step-h"><span class="uc-step-n">1</span>Pain point &rarr; product mapping</div>'+
         '<p class="uc-step-sub">For each customer pain point, name the product/feature you propose and how it addresses it.</p>'+
         '<div class="uc-table-wrap"><table class="uctab"><thead><tr><th>Customer pain point</th><th>Proposed product(s)</th><th>How it addresses / why</th></tr></thead><tbody>'+painRows+'</tbody></table></div>'+
@@ -1733,6 +1774,10 @@
     }
     var addBtn=$("#ucAddProd");
     if(addBtn) addBtn.addEventListener("click", function(){ addProdRow(); pushDraftFields(uc.n); });
+
+    // "What good looks like" — opens the sample in a modal so teams can calibrate without leaving the workspace
+    var sampleBtn=$("#ucSampleBtn");
+    if(sampleBtn) sampleBtn.addEventListener("click", openSampleModal);
 
     // diagram (per use case) — shared with the whole team and viewable in the workspace
     var diagKey="ztds.ucdiag."+uc.n+"."+ucTeamKey();


### PR DESCRIPTION
Makes "What good looks like" a button teams can pop open right where they're working, instead of a section they have to leave the workspace to find.

## What changed (`zero-trust-design-sprint.html`)
- Added a **See what "good" looks like** button at the top of every use-case workspace (just above step 1, amber-accented so it reads as a helper).
- Clicking it opens the calibration **sample in a modal** — the example pain→product mapping, the products (how/why) table, and the strong-diagram note — so teams can calibrate depth and format without navigating away to the briefing page.
- Modal closes on the backdrop, the × button, or Escape; reuses the existing modal styling in the dark theme.

The sample still lives on the briefing page too (for pre-reading before the clock starts) — this just brings it to the point of use.

## Testing
- New Playwright test (5/5): button present in the workspace, modal opens with the sample content (2 tables, Cisco ISE, the callout), and closes on both backdrop click and Escape.
- Full regression suite: **14 passed, 0 failed**, no JS errors.
- Screenshot of the open modal reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_