### PR TITLE
Redesign use-case tile icons — distinct, professional glyphs per mission

### DIFF
--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -579,9 +579,9 @@
   .uc-tile.locked,.uc-tile.soon{cursor:not-allowed}
   .uc-tile.open{border-color:var(--cyan)}
   .ut-art{position:relative;aspect-ratio:16/10;display:flex;align-items:center;justify-content:center}
-  .ut-art svg{width:62px;height:62px;stroke:#fff;fill:none;stroke-linecap:round;stroke-linejoin:round;opacity:.96;filter:drop-shadow(0 4px 10px rgba(0,0,0,.25))}
-  .uc-tile.locked .ut-art,.uc-tile.soon .ut-art{filter:grayscale(.4) brightness(.92)}
-  .uc-tile.locked .ut-art svg,.uc-tile.soon .ut-art svg{opacity:.5}
+  .ut-art svg{width:66px;height:66px;stroke:#fff;fill:none;stroke-linecap:round;stroke-linejoin:round;opacity:.96;filter:drop-shadow(0 4px 10px rgba(0,0,0,.25))}
+  .uc-tile.locked .ut-art,.uc-tile.soon .ut-art{filter:saturate(.85) brightness(.9)}
+  .uc-tile.locked .ut-art svg,.uc-tile.soon .ut-art svg{opacity:.82}
   .ut-lock,.ut-check{position:absolute;top:10px;right:10px;width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:15px}
   .ut-lock{background:rgba(6,20,44,.42);color:#fff}
   .ut-check{background:var(--green);color:#fff;font-weight:800}
@@ -1530,12 +1530,48 @@
 
   // ----- per-use-case tile artwork (inline SVG icons) -----
   function ucArt(n){
+    // Each use case gets a distinct, professional two-tone glyph (white stroke on the tile
+    // gradient, with a faint translucent fill for depth). Themes are indicative for the
+    // placeholder use cases — remap freely when UC2–5 get their real titles.
+    var f='fill="rgba(255,255,255,.14)"', dot='fill="#fff" stroke="none"';
     var art={
-      1:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M12 3l7 3v5c0 4.4-3 7.6-7 8.7-4-1.1-7-4.3-7-8.7V6z"/><path d="M9 12l2 2 4-4"/></svg>',
-      2:'<svg viewBox="0 0 24 24" stroke-width="1.6"><circle cx="12" cy="8" r="3.2"/><path d="M5.5 20a6.5 6.5 0 0113 0"/><path d="M18 3l1.4 2.6L22 7l-2.6 1.4L18 11l-1.4-2.6L14 7l2.6-1.4z"/></svg>',
-      3:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M7 18a4 4 0 01-.5-8A5.5 5.5 0 0117 8.5 3.8 3.8 0 0117 18z"/><rect x="10" y="13" width="5" height="4.5" rx="1"/><path d="M11 13v-1a1.5 1.5 0 013 0v1"/></svg>',
-      4:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M3 12h3l2.5 6 4-13 2.5 9 1.5-2H21"/></svg>',
-      5:'<svg viewBox="0 0 24 24" stroke-width="1.6"><path d="M6 21V4"/><path d="M6 4h11l-2 3 2 3H6"/><path d="M4 21h4"/></svg>'
+      // 1 · Segmentation — a protected shield split into isolated zones, each with its own asset
+      1:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
+          '<path d="M12 2.6l7 2.8V11c0 4.6-3 7.9-7 9.2-4-1.3-7-4.6-7-9.2V5.4z" '+f+'/>'+
+          '<path d="M6 9.4h12"/><path d="M6.6 13.6h10.8"/>'+
+          '<circle cx="9" cy="7" r=".95" '+dot+'/><circle cx="14.6" cy="11.5" r=".95" '+dot+'/><circle cx="9.8" cy="16.3" r=".95" '+dot+'/>'+
+        '</svg>',
+      // 2 · Identity & access — a fingerprint (who + which device is trusted)
+      2:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
+          '<path d="M5.3 10.4a7 7 0 0113.4 0"/>'+
+          '<path d="M8 11a4 4 0 018 0v1.6"/>'+
+          '<path d="M10.2 11.2a1.8 1.8 0 013.6.2v3.1a5 5 0 00.9 2.9"/>'+
+          '<path d="M12 12.5v4.4"/>'+
+          '<path d="M8.5 14.9a6.5 6.5 0 001 4.6"/>'+
+          '<path d="M15.7 16.2a7 7 0 001 2.9"/>'+
+        '</svg>',
+      // 3 · Cloud & hybrid workloads — a cloud fanning out to on-prem / cloud nodes
+      3:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
+          '<path d="M8 12.8h7.6a3 3 0 00.5-5.95A4.5 4.5 0 007.3 6 3.1 3.1 0 007.7 12.8z" '+f+'/>'+
+          '<path d="M12 12.8v2.4"/><path d="M6 15.2h12"/><path d="M6 15.2v1.1M12 15.2v1.1M18 15.2v1.1"/>'+
+          '<rect x="4.3" y="16.5" width="3.4" height="3" rx=".6"/>'+
+          '<rect x="10.3" y="16.5" width="3.4" height="3" rx=".6"/>'+
+          '<rect x="16.3" y="16.5" width="3.4" height="3" rx=".6"/>'+
+        '</svg>',
+      // 4 · Compliance & audit — a certification medal with ribbon, passing the check
+      4:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
+          '<path d="M9 13.4L7 21l5-2.6L17 21l-2-7.6"/>'+
+          '<circle cx="12" cy="9" r="5.2" '+f+'/>'+
+          '<path d="M9.7 9.1l1.6 1.6 3.1-3.4"/>'+
+        '</svg>',
+      // 5 · Threat detection & response — a radar sweep picking up a blip
+      5:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
+          '<circle cx="12" cy="12" r="8.5" '+f+'/>'+
+          '<circle cx="12" cy="12" r="4.7"/>'+
+          '<path d="M12 12l7-4"/>'+
+          '<circle cx="12" cy="12" r="1.4" '+dot+'/>'+
+          '<circle cx="15.8" cy="8.4" r="1.2" '+dot+'/>'+
+        '</svg>'
     };
     return art[n]||art[5];
   }
@@ -1549,7 +1585,9 @@
     USE_CASES.forEach(function(uc){
       var unlocked = ucIsUnlocked(uc.n) && !uc.locked;
       var submitted = ucIsSubmitted(uc.n);
-      var g = submitted ? "#1f8a63,#27A276" : uc.locked ? "#5b6b81,#8291a6" : unlocked ? "#0a5a99,#00BCEB" : "#5b6b81,#8291a6";
+      // each use case has its own signature colour so the grid reads as five distinct missions
+      var SIG = {1:"#0a5a99,#00BCEB", 2:"#6D28A8,#B072E8", 3:"#0E7C63,#2FBF9B", 4:"#B5711A,#F0A63C", 5:"#B03A54,#E8607F"};
+      var g = submitted ? "#1f8a63,#27A276" : (SIG[uc.n] || "#0a5a99,#00BCEB");
       var stateCls = uc.locked ? "soon" : submitted ? "done" : unlocked ? "open" : "locked";
       var badge = uc.locked ? "Coming soon" : submitted ? "Submitted" : unlocked ? "Open →" : "Locked";
       var note = uc.locked ? "Added soon" : (!unlocked ? ("Submit Use Case "+(uc.n-1)+" first") : (submitted ? "Tap to review / re-submit" : "Tap to start"));


### PR DESCRIPTION
Makes the use-case icons visual, professional, and unique. The five tiles previously shared thin, generic line icons and most sat on the same grey "locked" background, so the grid read flat.

## What changed (`zero-trust-design-sprint.html`)
- **New icon per use case** — each a distinct two-tone glyph (white stroke + a faint translucent fill for depth) with a clearly different silhouette:
  1. **Segmented shield** — segmentation / managed environment
  2. **Fingerprint** — identity & access
  3. **Cloud → on-prem/cloud nodes** — hybrid workloads
  4. **Certification medal + ribbon** — compliance & audit
  5. **Radar sweep + blip** — threat detection & response
- **Signature colour per use case** (cyan / violet / teal / amber / rose), shown in every state; a submitted tile still turns green.
- **Locked tiles keep their colour** (saturate/brightness dim instead of grey + half-opacity) so the redesigned icon stays visible — the 🔒 badge and "Coming soon" text remain the availability cue.
- Bumped icon size 62→66px for presence.

Themes for UC2–5 are indicative placeholders (those use cases are still locked stubs) — trivially remappable in `ucArt()` / the `SIG` map when they get real titles.

## Testing
- Full regression suite: **14 passed, 0 failed**, no JS errors (includes the tile check: 5 tiles, 5 icon SVGs, "Start here" flag, 4 locked).
- Screenshots of all five icons (full-colour and real locked states) reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_