### PR TITLE
Use-case tile icons: cohesive Zero Trust Access / security set

### DIFF
--- a/zero-trust-design-sprint.html
+++ b/zero-trust-design-sprint.html
@@ -1549,12 +1549,12 @@
 
   // ----- per-use-case tile artwork (inline SVG icons) -----
   function ucArt(n){
-    // Each use case gets a distinct, professional two-tone glyph (white stroke on the tile
-    // gradient, with a faint translucent fill for depth). Themes are indicative for the
-    // placeholder use cases — remap freely when UC2–5 get their real titles.
+    // A cohesive Zero Trust Access / security icon set — one glyph per ZTA pillar (white stroke on
+    // the tile gradient, faint translucent fill for depth). Themes are indicative for the placeholder
+    // use cases — remap freely when UC2–5 get their real titles.
     var f='fill="rgba(255,255,255,.14)"', dot='fill="#fff" stroke="none"';
     var art={
-      // 1 · Segmentation — a protected shield split into isolated zones, each with its own asset
+      // 1 · Network segmentation — a protected shield split into isolated zones, each with its own asset
       1:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
           '<path d="M12 2.6l7 2.8V11c0 4.6-3 7.9-7 9.2-4-1.3-7-4.6-7-9.2V5.4z" '+f+'/>'+
           '<path d="M6 9.4h12"/><path d="M6.6 13.6h10.8"/>'+
@@ -1569,21 +1569,20 @@
           '<path d="M8.5 14.9a6.5 6.5 0 001 4.6"/>'+
           '<path d="M15.7 16.2a7 7 0 001 2.9"/>'+
         '</svg>',
-      // 3 · Cloud & hybrid workloads — a cloud fanning out to on-prem / cloud nodes
+      // 3 · Device trust & posture — a verified endpoint (screen with a health check)
       3:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
-          '<path d="M8 12.8h7.6a3 3 0 00.5-5.95A4.5 4.5 0 007.3 6 3.1 3.1 0 007.7 12.8z" '+f+'/>'+
-          '<path d="M12 12.8v2.4"/><path d="M6 15.2h12"/><path d="M6 15.2v1.1M12 15.2v1.1M18 15.2v1.1"/>'+
-          '<rect x="4.3" y="16.5" width="3.4" height="3" rx=".6"/>'+
-          '<rect x="10.3" y="16.5" width="3.4" height="3" rx=".6"/>'+
-          '<rect x="16.3" y="16.5" width="3.4" height="3" rx=".6"/>'+
+          '<rect x="3.5" y="4.5" width="17" height="11.2" rx="1.6" '+f+'/>'+
+          '<path d="M8.3 9.9l2.4 2.4 5-5"/>'+
+          '<path d="M12 15.7v2.6"/><path d="M8.4 20h7.2"/>'+
         '</svg>',
-      // 4 · Compliance & audit — a certification medal with ribbon, passing the check
+      // 4 · Least-privilege access — a padlock guarding who gets in (access control / policy)
       4:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
-          '<path d="M9 13.4L7 21l5-2.6L17 21l-2-7.6"/>'+
-          '<circle cx="12" cy="9" r="5.2" '+f+'/>'+
-          '<path d="M9.7 9.1l1.6 1.6 3.1-3.4"/>'+
+          '<rect x="4.7" y="10.3" width="14.6" height="9.7" rx="2.2" '+f+'/>'+
+          '<path d="M7.7 10.3V7.7a4.3 4.3 0 018.6 0v2.6"/>'+
+          '<circle cx="12" cy="14.4" r="1.5" '+dot+'/>'+
+          '<path d="M12 15.7v2.2"/>'+
         '</svg>',
-      // 5 · Threat detection & response — a radar sweep picking up a blip
+      // 5 · Continuous monitoring & threat response — a radar sweep picking up a blip
       5:'<svg viewBox="0 0 24 24" stroke-width="1.5">'+
           '<circle cx="12" cy="12" r="8.5" '+f+'/>'+
           '<circle cx="12" cy="12" r="4.7"/>'+


### PR DESCRIPTION
Makes the use-case tile icons a cohesive **Zero Trust Access / security** set. Three were already on-theme; two weren't (a cloud + servers, a compliance medal) — swapped so all five read as ZTA pillars.

| # | Use case theme | Icon |
|---|---|---|
| 1 | Network segmentation | Shield split into isolated zones *(kept)* |
| 2 | Identity & access | Fingerprint *(kept)* |
| 3 | **Device trust & posture** | **Screen with a health check** *(was cloud/servers)* |
| 4 | **Least-privilege access** | **Padlock with keyhole** *(was compliance medal)* |
| 5 | Continuous monitoring & threat response | Radar sweep + blip *(kept)* |

Each stays a distinct silhouette with the same two-tone style (white stroke + faint fill) and the per-use-case signature colour. Themes remain indicative for the placeholder use cases (UC2–5) — easy to remap in `ucArt()` when they get real titles.

## Testing
- Full regression **14/14**, no JS errors.
- Screenshot of all five icons (full colour) reviewed — clean, distinct, and clearly security/ZTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5ZjLFYDFwWKXPA737imM6)_